### PR TITLE
Feature/cancel request

### DIFF
--- a/examples/example.html
+++ b/examples/example.html
@@ -88,7 +88,7 @@
 
       ////////////////////////////////////////////////
 
-      // App Steup     
+      // App Steup
       let connect = new uportconnect.Connect('Uport Example')
       let web3 = connect.getWeb3()
 
@@ -149,6 +149,8 @@
 
         status.updateStatus(statusMsg).then(tx => {
           console.log(tx)
+        }).catch(err => {
+          console.log(err)
         })
 
         }

--- a/src/Connect.js
+++ b/src/Connect.js
@@ -80,10 +80,10 @@ class Connect {
   request ({uri, topic, uriHandler}) {
     this.isOnMobile
       ? this.mobileUriHandler(uri)
-      : (uriHandler || this.uriHandler)(uri)
+      : (uriHandler || this.uriHandler)(uri, topic.stop)
     if (this.closeUriHandler) {
       return new Promise((resolve, reject) => {
-        topic.then(res => {
+        topic.listen().then(res => {
           this.closeUriHandler()
           resolve(res)
         }, error => {
@@ -91,7 +91,7 @@ class Connect {
           reject(error)
         })
       })
-    } else return topic
+    } else return topic.listen()
   }
 
   // TODO support contract.new (maybe?)

--- a/src/topicFactory.js
+++ b/src/topicFactory.js
@@ -3,91 +3,100 @@ import qs from 'qs'
 import randomString from './util/randomString'
 const CHASQUI_URL = 'https://chasqui.uport.me/api/v1/topic/'
 
-function TopicFactory (isOnMobile, pollingInterval = 2000, chasquiUrl = CHASQUI_URL) {
-  function waitForHashChange (topicName, cb) {
-    window.onhashchange = function () {
-      if (window.location.hash) {
-        const params = qs.parse(window.location.hash.slice(1))
-        if (params[topicName]) {
-          window.onhashchange = function () {}
-          window.location.hash = ''
-          cb(null, params[topicName])
-        } else if (params.error) {
-          window.onhashchange = function () {}
-          window.location.hash = ''
-          cb(params.error)
-        }
-      }
-    }
-  }
+// TODO may want return function named still for readability.
+const TopicFactory = (isOnMobile, pollingInterval = 2000, chasquiUrl = CHASQUI_URL) => (topicName) => {
 
-  function pollForResult (topicName, url, cb) {
-    let interval = setInterval(
-      () => {
+    const url = isOnMobile ? window.location.href : chasquiUrl + randomString(16)
+
+    return (() => {
+      let stopBool = false
+
+      const clearTopic = (url) => {
         nets({
           uri: url,
-          method: 'GET',
+          method: 'DELETE',
           rejectUnauthorized: false
-        },
-        function (err, res, body) {
-          if (err) return cb(err)
+        }, (err) => { if (err) { throw err } /* Errors withouth this cb */ })
+      }
 
-          // parse response into raw account
-          let data
-          try {
-            data = JSON.parse(body).message
-            if (data.error) {
-              clearInterval(interval)
-              return cb(data.error)
+      const waitForHashChange = (topicName, cb) => {
+        window.onhashchange = () => {
+          if (window.location.hash) {
+            const params = qs.parse(window.location.hash.slice(1))
+            if (params[topicName]) {
+              window.onhashchange = () => {}
+              window.location.hash = ''
+              cb(null, params[topicName])
+            } else if (params.error) {
+              window.onhashchange = () => {}
+              window.location.hash = ''
+              cb(params.error)
             }
-          } catch (err) {
-            console.error(err.stack)
-            clearInterval(interval)
-            return cb(err)
           }
-          // Check for param, stop polling and callback if present
-          if (data && data[topicName]) {
-            clearInterval(interval)
-            clearTopic(url)
-            return cb(null, data[topicName])
-          }
-        })
-      }, pollingInterval)
-  }
-
-
-  function clearTopic (url) {
-    nets({
-      uri: url,
-      method: 'DELETE',
-      rejectUnauthorized: false
-    }, function (err) { if (err) { throw err } /* Errors withouth this cb */ })
-  }
-
-  function newTopic (topicName) {
-    let url
-    if (isOnMobile) {
-      url = window.location.href
-    } else {
-      url = chasquiUrl + randomString(16)
-    }
-    const topic = new Promise((resolve, reject) => {
-      const cb = (error, response) => {
-        if (error) return reject(error)
-        resolve(response)
+        }
       }
-      if (isOnMobile) {
-        waitForHashChange(topicName, cb)
-      } else {
-        pollForResult(topicName, url, cb)
+
+      const pollForResult = (topicName, url, cb) => {
+        let interval = setInterval(
+
+          () => {
+            nets({
+              uri: url,
+              method: 'GET',
+              rejectUnauthorized: false
+            },
+
+           (err, res, body) => {
+              if (err) return cb(err)
+              // TODO what is good error message
+              if (stopBool) return cb(new Error('Request Cancelled'))
+              // parse response into raw account
+              let data
+
+              try {
+                data = JSON.parse(body).message
+                if (data.error) {
+                  clearInterval(interval)
+                  return cb(data.error)
+                }
+              } catch (err) {
+                console.error(err.stack)
+                clearInterval(interval)
+                return cb(err)
+              }
+              // Check for param, stop polling and callback if present
+              if (data && data[topicName]) {
+                clearInterval(interval)
+                clearTopic(url)
+                return cb(null, data[topicName])
+              }
+            })
+          }, pollingInterval)
       }
-    })
-    topic.url = url
-    return topic
+
+      return {
+        stop: () => {
+          stopBool = true
+        },
+        url: url,
+        stopBool: stopBool,
+        listen:  () => (
+          new Promise((resolve, reject) => {
+            const cb = (error, response) => {
+              if (error) return reject(error)
+              resolve(response)
+            }
+            if (isOnMobile) {
+              waitForHashChange(topicName, cb)
+            } else {
+              pollForResult(topicName, url, cb)
+            }
+          })
+        )
+      }
+    })()
   }
 
-  return newTopic
-}
 
 
 export default TopicFactory

--- a/src/util/qrdisplay.js
+++ b/src/util/qrdisplay.js
@@ -6,12 +6,14 @@ const getQRDataURI = (data) => {
   return 'data:image/png;charset=utf-8;base64, ' + pngBuffer.toString('base64')
 }
 
-const openQr = (data) => {
+const openQr = (data, stop) => {
     let uportQR = getUportQRDisplay()
     uportQR.style.display = 'block'
 
     let dataUri = getQRDataURI(data)
     let qrImg = uportQR.children[0].children[0]
+    let cancelButton = uportQR.children[0].children[2]
+    cancelButton.addEventListener('click', (event) => { stop() })
     qrImg.setAttribute('src', dataUri)
   }
 
@@ -65,7 +67,7 @@ const getUportQRDisplay = () => {
   }
 
 
-export { 
+export {
   getUportQRDisplay,
   resetQRCancellation,
   isQRCancelled,
@@ -73,4 +75,3 @@ export {
   openQr,
   getQRDataURI
 }
-

--- a/test/Connect.js
+++ b/test/Connect.js
@@ -23,15 +23,19 @@ function mockCredentials (receive) {
 // const credentials = new Credentials({signer, address: '0xa19320ce2f72768054ac01248734c7d4f9929f6d', registry})
 
 const mockTopic = (response = UPORT_ID) => {
-  const topic = new Promise((resolve, reject) => resolve(response))
-  topic.url = 'https://chasqui.uport.me/api/v1/topic/123'
-  return topic
+  return {
+    stop: () => {},
+    listen: () => (new Promise((resolve, reject) => resolve(response))),
+    url: 'https://chasqui.uport.me/api/v1/topic/123'
+  }
 }
 
 const errorTopic = () => {
-  const topic = new Promise((resolve, reject) => reject(new Error('It broke')))
-  topic.url = 'https://chasqui.uport.me/api/v1/topic/123'
-  return topic
+  return {
+    stop: () => {},
+    listen: () => (new Promise((resolve, reject) => reject(new Error('It broke')))),
+    url: 'https://chasqui.uport.me/api/v1/topic/123'
+  }
 }
 
 describe('Connect', ()=> {

--- a/test/topicFactory.js
+++ b/test/topicFactory.js
@@ -15,7 +15,7 @@ describe('TopicFactory', function () {
     it('Correctly polls for data', (done) => {
       let data = '0x123456789'
       const topic = topicFactory('access_token')
-      topic.then((res) => {
+      topic.listen().then((res) => {
         assert.equal(res, data, 'Should get correct data from server.')
         done()
       }).catch(err => {
@@ -31,7 +31,7 @@ describe('TopicFactory', function () {
     it('Gives error if polling yields error', (done) => {
       const data = 'some weird error'
       const topic = topicFactory('tx')
-      topic.then(res => {
+      topic.listen().then(res => {
         assert.equal(res, null, 'Should not have data')
         done()
       }).catch(err => {
@@ -46,7 +46,7 @@ describe('TopicFactory', function () {
 
     it('Has cleared topic', (done) => {
       const topic = topicFactory('access_token')
-      topic.then((res) => {
+      topic.listen().then((res) => {
         setTimeout(
           () => postData(topic.url, 'access_token', '0x234', (e, r, b) => {
             assert.equal(b.data.id, 'not found')
@@ -69,7 +69,7 @@ describe('TopicFactory', function () {
     it('Correctly waits for data', (done) => {
       let data = '0x123456789'
       const topic = topicFactory('access_token')
-      topic.then(res => {
+      topic.listen().then(res => {
         assert.equal(res, data, 'Should get correct data.')
         done()
       })
@@ -80,7 +80,7 @@ describe('TopicFactory', function () {
     it('Gives error if error posted', (done) => {
       let data = 'some weird error'
       const topic = topicFactory('access_token')
-      topic.catch(err => {
+      topic.listen().catch(err => {
         assert.equal(err, data)
         done()
       })


### PR DESCRIPTION
This returns a function that can be called to cancel a request, a request polls untils it gets a
response, but if a user cancels on their phone (or doesn't scan) then they must be able to be given a way to cancel it, this allows a developer to provide that. 

Things to consider:
TopicFactory code is not super readable
This does not change any interface in connect, but does change what TopicFactory(...)(....) returns
TopicFactory(...)(....) will now return an object with { stop: func, listen: promise, uri: 'uri'}
I believed it minimized overall changes, and the ability to cancel/stop is essential