### PR TITLE
Attest Credentials in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ uport.requestCredentials().then((credentials) => {
 })
 ```
 
-If all we want is the address of the connected user we can use `connect()`:
+If all we want is the address of the connected user we can use `requestAddress()`:
 
 ```javascript
 uport.requestAddress().then((address) => {

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,6 @@ machine:
 test:
   override:
     - npm run karma-CI
-    - npm run karma-CI-integration
   post:
     -  bash <(curl -s https://codecov.io/bash)
     -  npm run build-dist && npm run build-dist-prod

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "qr-image": "^3.1.0",
     "qs": "^6.2.1",
     "request": "^2.75.0",
-    "uport": "^0.2.1",
+    "uport": "^0.2.2",
     "web3-provider-engine": "^8.0.8"
   },
   "devDependencies": {

--- a/src/Connect.js
+++ b/src/Connect.js
@@ -30,15 +30,16 @@ class Connect {
    * @memberof    Uport
    * @method      constructor
    * @param       {String}            appName                the name of your app
-   * @param       {Object}            opts                    optional parameters
-   * @param       {String}            opts.clientId           a uport id for your application
-   * @param       {Object}            opts.credentials        configured Credentials object from http://github.com/uport-project/uport-js object. Configure this is you need to create signed requests
-   * @param       {String}            opts.rpcUrl             a JSON rpc url (defaults to https://ropsten.infura.io)
-   * @param       {String}            opts.infuraApiKey       Infura API Key (register here http://infura.io/register.html)
-   * @param       {Function}          opts.topicFactory       A function creating a topic
+   * @param       {Object}            opts                   optional parameters
+   * @param       {Object}            opts.credentials       pre-configured Credentials object from http://github.com/uport-project/uport-js object. Configure this is you need to create signed requests
+   * @param       {Function}          opts.signer            signing function which will be used to sign JWT's in the credentials object
+   * @param       {String}            opts.clientId          a uport id for your application this will be used in the default credentials object
+   * @param       {String}            opts.rpcUrl            a JSON rpc url (defaults to https://ropsten.infura.io)
+   * @param       {String}            opts.infuraApiKey      Infura API Key (register here http://infura.io/register.html)
+   * @param       {Function}          opts.topicFactory      A function creating a topic
    * @param       {Function}          opts.uriHandler        Function to present QR code or other UX to approve request
    * @param       {Function}          opts.mobileUriHandler  Function to request in mobile browsers
-   * @param       {Function}          opts.closeUriHandler       Function to hide UX created with uriHandler after request is done
+   * @param       {Function}          opts.closeUriHandler   Function to hide UX created with uriHandler after request is done
    * @return      {Object}            self
    */
 
@@ -54,7 +55,7 @@ class Connect {
     this.uriHandler = opts.uriHandler || openQr
     this.mobileUriHandler = opts.mobileUriHandler || mobileUriHandler
     this.closeUriHandler = opts.closeUriHandler || (this.uriHandler === openQr ? closeQr : undefined)
-    this.credentials = opts.credentials || new Credentials()
+    this.credentials = opts.credentials || new Credentials({address: opts.clientId, signer: opts.signer})
     this.canSign = !!this.credentials.settings.signer
   }
 

--- a/src/Connect.js
+++ b/src/Connect.js
@@ -77,6 +77,16 @@ class Connect {
     return this.requestCredentials({}, uriHandler).then((profile) => profile.address)
   }
 
+  attestCredentials ({sub, claim, exp}, uriHandler = null) {
+    return this.credentials.attest({ sub, claim, exp }).then(jwt => {
+      const uri = `me.uport:add?attestations=${encodeURIComponent(jwt)}`
+      this.isOnMobile
+        ? this.mobileUriHandler(uri)
+        : (uriHandler || this.uriHandler)(uri)
+      return true
+    })
+  }
+
   request ({uri, topic, uriHandler}) {
     this.isOnMobile
       ? this.mobileUriHandler(uri)

--- a/test/Connect.js
+++ b/test/Connect.js
@@ -1,6 +1,6 @@
 import { expect, assert } from 'chai'
 import { Connect } from './uport-connect'
-// import { Credentials, SimpleSigner } from 'uport'
+import { Credentials } from 'uport'
 import { openQr, closeQr } from '../src/util/qrdisplay'
 // import MockDate from 'mockdate'
 // MockDate.set(1485321133996)
@@ -51,6 +51,7 @@ describe('Connect', ()=> {
       expect(uport.rpcUrl).to.equal('https://ropsten.infura.io/test-app')
       expect(uport.uriHandler.name).to.equal('openQr')
       expect(uport.closeUriHandler.name).to.equal('closeQr')
+      expect(uport.credentials).to.be.an.instanceof(Credentials)
     })
 
     it('does not have a closeUriHandler if not using built in openQr', () => {
@@ -58,6 +59,15 @@ describe('Connect', ()=> {
       const uport = new Connect('test', {uriHandler: noop})
       expect(uport.uriHandler).to.equal(noop)
       expect(uport.closeUriHandler).to.be.undefined
+    })
+
+    it('configures credentials correctly', () => {
+      const signer = () => null
+      const uport = new Connect('test app', {clientId: CLIENT_ID, signer})
+      expect(uport.credentials).to.be.an.instanceof(Credentials)
+      expect(uport.clientId).to.equal(CLIENT_ID)
+      expect(uport.credentials.settings.address).to.equal(CLIENT_ID)
+      expect(uport.credentials.settings.signer).to.equal(signer)
     })
   })
 

--- a/test/Connect.js
+++ b/test/Connect.js
@@ -259,7 +259,7 @@ describe('Connect', ()=> {
   describe('attestCredentials', () => {
     const ATTESTATION = 'ATTESTATION'
     const PAYLOAD = {sub: '0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', claim: { name: 'Bob' }, exp: 123123123}
-    it('provides attestation to user', (done) => {
+    it('provides attestation to user using default uriHandler', (done) => {
       let opened
       const uport = new Connect('UportTests', {
         uriHandler: (uri) => {
@@ -280,6 +280,76 @@ describe('Connect', ()=> {
         done()
       })
     })
+
+    it('provides attestation to user using mobileUriHandler', (done) => {
+      let opened
+      const uport = new Connect('UportTests', {
+        isMobile: true,
+        mobileUriHandler: (uri) => {
+          opened = true
+          expect(uri).to.equal(`me.uport:add?attestations=${ATTESTATION}`)
+        },
+        credentials: mockAttestingCredentials((payload) => {
+          expect(payload).to.deep.equal(PAYLOAD)
+          return ATTESTATION
+        })
+      })
+      uport.attestCredentials(PAYLOAD).then((result) => {
+        expect(result).to.be.true
+        expect(opened).to.be.true
+        done()
+      }, error => {
+        console.err(error)
+        done()
+      })
+    })
+
+    it('provides attestation to user using overriden uriHandler', (done) => {
+      let opened
+      const uport = new Connect('UportTests', {
+        credentials: mockAttestingCredentials((payload) => {
+          expect(payload).to.deep.equal(PAYLOAD)
+          return ATTESTATION
+        })
+      })
+      uport.attestCredentials(PAYLOAD, (uri) => {
+        opened = true
+        expect(uri).to.equal(`me.uport:add?attestations=${ATTESTATION}`)
+      }).then((result) => {
+        expect(result).to.be.true
+        expect(opened).to.be.true
+        done()
+      }, error => {
+        console.err(error)
+        done()
+      })
+    })
+
+    it('provides attestation to user using mobileUriHandler even if there is an overridden uriHandler', (done) => {
+      let opened
+      const uport = new Connect('UportTests', {
+        isMobile: true,
+        mobileUriHandler: (uri) => {
+          opened = true
+          expect(uri).to.equal(`me.uport:add?attestations=${ATTESTATION}`)
+        },
+        credentials: mockAttestingCredentials((payload) => {
+          expect(payload).to.deep.equal(PAYLOAD)
+          return ATTESTATION
+        })
+      })
+      uport.attestCredentials(PAYLOAD, (uri) => {
+        assert.fail()
+      }).then((result) => {
+        expect(result).to.be.true
+        expect(opened).to.be.true
+        done()
+      }, error => {
+        console.err(error)
+        done()
+      })
+    })
+
   })
 
   describe('sendTransaction', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6359,9 +6359,9 @@ uport-lite@^0.1.1:
     base-x "^2.0.3"
     xmlhttprequest "^1.8.0"
 
-uport@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/uport/-/uport-0.2.1.tgz#34b6c293e7ece2083505635463e2997ffd80152e"
+uport@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/uport/-/uport-0.2.2.tgz#0a3fe559006ab4fb1a13f6b0ea8b069cf18807c3"
   dependencies:
     jsontokens "^0.6.5"
     uport-lite "^0.1.1"


### PR DESCRIPTION
- [x] add `attestCredentials`
- [x] make it easier to configure a signer
- [x] throw an error if no signer was configured