### PR TITLE
feat(uport): allow requests to be cancelled and qrdisplay to cancel

### DIFF
--- a/src/Connect.js
+++ b/src/Connect.js
@@ -106,7 +106,7 @@ class Connect {
   request ({uri, topic, uriHandler}) {
     this.isOnMobile
       ? this.mobileUriHandler(uri)
-      : (uriHandler || this.uriHandler)(uri)
+      : (uriHandler || this.uriHandler)(uri, topic.cancel)
     if (this.closeUriHandler) {
       return new Promise((resolve, reject) => {
         topic.then(res => {
@@ -173,4 +173,3 @@ const paramsToUri = (params) => {
 }
 
 export default Connect
-

--- a/src/util/qrdisplay.js
+++ b/src/util/qrdisplay.js
@@ -6,12 +6,14 @@ const getQRDataURI = (data) => {
   return 'data:image/png;charset=utf-8;base64, ' + pngBuffer.toString('base64')
 }
 
-const openQr = (data) => {
+const openQr = (data, cancel) => {
     let uportQR = getUportQRDisplay()
     uportQR.style.display = 'block'
 
     let dataUri = getQRDataURI(data)
     let qrImg = uportQR.children[0].children[0]
+    let cancelButton = uportQR.children[0].children[2]
+    cancelButton.addEventListener('click', (event) => { cancel() })
     qrImg.setAttribute('src', dataUri)
   }
 
@@ -64,8 +66,7 @@ const getUportQRDisplay = () => {
     return bg
   }
 
-
-export { 
+export {
   getUportQRDisplay,
   resetQRCancellation,
   isQRCancelled,
@@ -73,4 +74,3 @@ export {
   openQr,
   getQRDataURI
 }
-


### PR DESCRIPTION
This returns a function that can be called to cancel a request, a request polls untils it gets a

response, but if a user cancels on their phone then they must be able to be given a way to cancel it

in the app, tthis allows developers to provide that.