### PR TITLE
WIP: add default activate uport button for txn signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ Also, the following calls will show a QR code for the user to scan:
 
 Check out the examples folder too for how to integrate **uport** in your DApp
 
+
+#### One line Integration to allow users to sign transactions with uPort.
+
+If you already have a dapp this is the quickest way to support uPort for your users. This will inject a uPort web3 object which will use our default transaction signing flows with QR codes and our mobile app.
+
+TODO: more details, works if dapps already support metamask, can not load anything regarding accounts, so maybe this implementation does not make sense.
+
+```html
+<button id="uport-activate"> Use uPort </button> <script async src="../dist/uport-connect.js" charset="utf-8"></script>
+```
 ---------------------------------------------
 
 ### Customizing QR code requests

--- a/src/index.js
+++ b/src/index.js
@@ -4,3 +4,19 @@ import { getQRDataURI, closeQr, openQr } from './util/qrdisplay'
 const QRUtil = { getQRDataURI, closeQr, openQr }
 import { SimpleSigner, Credentials } from 'uport'
 export { Connect, ConnectCore, QRUtil, SimpleSigner, Credentials }
+
+const injectWeb3 = () => {
+  // possibly pass some args in
+  const connect = new Connect('MyDapp')
+  window.web3 = connect.getWeb3()
+}
+
+window.addEventListener('load', () => {
+  const activateButton = document.getElementById('uport-activate')
+
+  const buttonStyle = "background-color: #1da1f2;border: 1px solid #1da1f2;color: #fff;-webkit-appearance: none;border-radius: 4px;cursor: pointer;display: inline-block;font: inherit;margin: 0;padding: 6px 13px;"
+  activateButton.setAttribute('style', buttonStyle)
+
+  // maybe store already set web3 to de activate uport
+  activateButton.addEventListener('click', injectWeb3)
+})


### PR DESCRIPTION
One line integration of uport to provide uPort txn signing to users.

```html
<button id="uport-activate"> Use uPort </button> <script async src="//unpkg.com/uport-connect/dist/uportconnect.js" charset="utf-8"></script>
```

Mostly exploring the simplest way for dapp developers to integrate uPort, especially into already existing code. This requires no use of specific uport features, but likely a developer would like to eventually use the additional features. This also may no make any sense as there is no web3 account available in this implementation, may be better to steer developers to our other implementation still which also only requires a few lines of code.

Further considerations: 

- will be useful to have some branded assets for developers (uport connect buttons, etc)
- similarly to this button a chrome extension could provide the same functionality across all existing dapps and could even persist the account (address) for dapps to use. All of this would work without any coordination with any dapps.