### PR TITLE
Refactor/connect cleanup

### DIFF
--- a/src/ConnectCore.js
+++ b/src/ConnectCore.js
@@ -16,8 +16,8 @@ function isMobile () {
   } else return false
 }
 
-function defaultUrlHandler (url) {
-  throw new Error(`No Url handler set to handle ${url}`)
+function defaultUriHandler (uri) {
+  throw new Error(`No URI handler set to handle ${uri}`)
 }
 /**
  * This class is the main entry point for interaction with uport.
@@ -53,7 +53,7 @@ class ConnectCore {
     this.provider = opts.provider
     this.isOnMobile = opts.isMobile || isMobile()
     this.topicFactory = opts.topicFactory || TopicFactory(this.isOnMobile)
-    this.uriHandler = opts.uriHandler || defaultUrlHandler
+    this.uriHandler = opts.uriHandler || defaultUriHandler
     this.mobileUriHandler = opts.mobileUriHandler
     this.closeUriHandler = opts.closeUriHandler
     this.credentials = opts.credentials || new Credentials({address: opts.clientId, signer: opts.signer})

--- a/src/ConnectCore.js
+++ b/src/ConnectCore.js
@@ -137,9 +137,8 @@ class ConnectCore {
   }
 
   // TODO support contract.new (maybe?)
-  contract (abi, uriHandler = this.uriHandler) {
-    const self = this
-    const txObjectHandler = (methodTxObject) => self.sendTransaction(methodTxObject, uriHandler)
+  contract (abi) {
+    const txObjectHandler = (methodTxObject, uriHandler) => this.sendTransaction(methodTxObject, uriHandler)
     return new ContractFactory(txObjectHandler)(abi)
   }
 

--- a/src/ConnectCore.js
+++ b/src/ConnectCore.js
@@ -139,12 +139,14 @@ class ConnectCore {
   // TODO support contract.new (maybe?)
   contract (abi, uriHandler = this.uriHandler) {
     const self = this
-    const txObjectHandler = (methodTxObject) => self.txObjectHandler(methodTxObject, uriHandler)
+    const txObjectHandler = (methodTxObject) => self.sendTransaction(methodTxObject, uriHandler)
     return new ContractFactory(txObjectHandler)(abi)
   }
 
   sendTransaction (txobj, uriHandler = this.uriHandler) {
-    return this.txObjectHandler(txobj, uriHandler)
+    const topic = this.topicFactory('tx')
+    let uri = paramsToUri(this.addAppParameters(txobj, topic.url))
+    return this.request({uri, topic, uriHandler})
   }
 
   addAppParameters (txObject, callbackUrl) {
@@ -159,12 +161,6 @@ class ConnectCore {
       appTxObject.client_id = this.clientId
     }
     return appTxObject
-  }
-
-  txObjectHandler (methodTxObject, uriHandler = this.uriHandler) {
-    const topic = this.topicFactory('tx')
-    let uri = paramsToUri(this.addAppParameters(methodTxObject, topic.url))
-    return this.request({uri, topic, uriHandler})
   }
 }
 

--- a/test/ConnectCore.js
+++ b/test/ConnectCore.js
@@ -60,7 +60,7 @@ describe('ConnectCore', () => {
       expect(uport.appName).to.equal('test app')
       expect(uport.infuraApiKey).to.equal('test-app')
       expect(uport.rpcUrl).to.equal('https://ropsten.infura.io/test-app')
-      expect(uport.uriHandler.name).to.equal('defaultUrlHandler')
+      expect(uport.uriHandler.name).to.equal('defaultUriHandler')
       expect(uport.closeUriHandler).to.equal(undefined)
       expect(uport.credentials).to.be.an.instanceof(Credentials)
       expect(uport.canSign).to.be.false
@@ -608,11 +608,13 @@ describe('ConnectCore', () => {
         },
         closeUriHandler: () => null
       })
-      const contract = uport.contract(miniTokenABI, (uri) => {
+
+      const overideUriHandler = (uri) => {
         expect(uri).to.equal(`me.uport:0x819320ce2f72768054ac01248734c7d4f9929f6c?function=transfer(address%200x3b2631d8e15b145fd2bf99fc5f98346aecdc394c%2C%20uint256%2012312)&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=0xa19320ce2f72768054ac01248734c7d4f9929f6d`)
-      })
-      const token = contract.at('0x819320ce2f72768054ac01248734c7d4f9929f6c')
-      token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312).then(txhash => {
+      }
+
+      const token = uport.contract(miniTokenABI).at('0x819320ce2f72768054ac01248734c7d4f9929f6c')
+      token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312, overideUriHandler).then(txhash => {
         expect(txhash).to.equal(FAKETX)
         done()
       })


### PR DESCRIPTION
Some minor cleanup, and primarily a fix for connect.contract to allow a  uriHandler to be passed on each call, it was ignoring it.