### PR TITLE
fix(connect): fix response not recieved on mobile, silent error

### DIFF
--- a/src/ConnectCore.js
+++ b/src/ConnectCore.js
@@ -182,7 +182,7 @@ class ConnectCore {
       ? this.mobileUriHandler(uri)
       : uriHandler(uri, topic.cancel)
 
-    if (this.closeUriHandler) {
+    if (!this.isOnMobile && this.closeUriHandler) {
       return new Promise((resolve, reject) => {
         topic.then(res => {
           this.closeUriHandler()

--- a/test/ConnectCore.js
+++ b/test/ConnectCore.js
@@ -160,8 +160,7 @@ describe('ConnectCore', () => {
         mobileUriHandler: (_uri) => {
           expect(_uri).to.equal(uri)
           opened = true
-        },
-        closeUriHandler: () => { closed = true }
+        }
       })
       uport.request({
         uri,
@@ -169,7 +168,6 @@ describe('ConnectCore', () => {
       }).then(response => {
         expect(response).to.equal(UPORT_ID)
         expect(opened).to.equal(true)
-        expect(closed).to.equal(true)
         done()
       }, error => {
         assert.fail()
@@ -184,8 +182,7 @@ describe('ConnectCore', () => {
         mobileUriHandler: (_uri) => {
           expect(_uri).to.equal(uri)
           opened = true
-        },
-        closeUriHandler: () => { closed = true }
+        }
       })
       uport.request({
         uri,
@@ -197,7 +194,6 @@ describe('ConnectCore', () => {
       }).then(response => {
         expect(response).to.equal(UPORT_ID)
         expect(opened).to.equal(true)
-        expect(closed).to.equal(true)
         done()
       }, error => {
         assert.fail()


### PR DESCRIPTION
this.closeUriHandler failed silently when default uriHandler not called and the promise would not reject or resolve, just leaving no response 

For all config functions in the future (added story) we should properly catch/propagate errors and reject promises if necessary, our code should be based on our assumed default functionality  