### PR TITLE
Feature/test function spies

### DIFF
--- a/src/ConnectCore.js
+++ b/src/ConnectCore.js
@@ -123,7 +123,11 @@ class ConnectCore {
    *  @param    {Function}                [uriHandler=this.uriHandler]    function to consume uri, can be used to display QR codes or other custom UX
    *  @return   {Promise<Object, Error>}                                  a promise which resolves with a response object or rejects with an error.
    */
+<<<<<<< HEAD
   requestCredentials (request = {}, uriHandler) {
+=======
+  requestCredentials (request = {}, uriHandler = this.uriHandler) {
+>>>>>>> feat: add multi-network support and configuration options
     const self = this
     const receive = this.credentials.receive.bind(this.credentials)
     const topic = this.topicFactory('access_token')

--- a/src/ConnectCore.js
+++ b/src/ConnectCore.js
@@ -123,11 +123,7 @@ class ConnectCore {
    *  @param    {Function}                [uriHandler=this.uriHandler]    function to consume uri, can be used to display QR codes or other custom UX
    *  @return   {Promise<Object, Error>}                                  a promise which resolves with a response object or rejects with an error.
    */
-<<<<<<< HEAD
   requestCredentials (request = {}, uriHandler) {
-=======
-  requestCredentials (request = {}, uriHandler = this.uriHandler) {
->>>>>>> feat: add multi-network support and configuration options
     const self = this
     const receive = this.credentials.receive.bind(this.credentials)
     const topic = this.topicFactory('access_token')

--- a/test/Connect.js
+++ b/test/Connect.js
@@ -21,7 +21,7 @@ describe('Connect', () => {
       const noop = (uri) => null
       const uport = new Connect('test', {uriHandler: noop})
       expect(uport.uriHandler).to.equal(noop)
-      expect(uport.closeUriHandler).to.be.undefined
+      expect(uport.closeUriHandler, 'uport.closeUriHandler').to.be.undefined
     })
   })
 })

--- a/test/ConnectCore.js
+++ b/test/ConnectCore.js
@@ -71,30 +71,30 @@ describe('ConnectCore', () => {
       const noop = (uri) => null
       const uport = new ConnectCore('test', {uriHandler: noop})
       expect(uport.uriHandler).to.equal(noop)
-      expect(uport.closeUriHandler).to.be.undefined
+      expect(uport.closeUriHandler, 'uport.closeUriHandler').to.be.undefined
     })
 
     it('configures credentials correctly', () => {
       const signer = () => null
       const uport = new ConnectCore('test app', {clientId: CLIENT_ID, signer})
       expect(uport.credentials).to.be.an.instanceof(Credentials)
-      expect(uport.clientId).to.equal(CLIENT_ID)
-      expect(uport.credentials.settings.address).to.equal(CLIENT_ID)
+      expect(uport.clientId, 'uport.clientId').to.equal(CLIENT_ID)
+      expect(uport.credentials.settings.address, 'uport.credentials.settings.address').to.equal(CLIENT_ID)
       expect(uport.credentials.settings.signer).to.equal(signer)
-      expect(uport.canSign).to.be.true
+      expect(uport.canSign, 'uport.canSign').to.be.true
     })
 
     it('configures the network in connect and in credentials give a supported string', () => {
        const uport = new ConnectCore('test app', {network: 'mainnet'})
-       expect(uport.network.id).to.equal('0x1')
-       expect('0x1' in uport.credentials.settings.networks).to.be.true
+       expect(uport.network.id, 'uport.network.id').to.equal('0x1')
+       expect('0x1' in uport.credentials.settings.networks, 'uport.credentials.settings.networks includes 0x1').to.be.true
     })
 
     it('configures the network in connect and in credentials given a well formed network config object', () => {
       const netConfig = { id: '0x5', registry: '0xab6c9051b9a1eg1abc1250f8b0640848c8ebfcg6', rpcUrl: 'https://somenet.io' }
       const uport = new ConnectCore('test app', {network: netConfig})
-      expect(uport.network.id).to.equal('0x5')
-      expect('0x5' in uport.credentials.settings.networks).to.be.true
+      expect(uport.network.id, 'uport.network.id').to.equal('0x5')
+      expect('0x5' in uport.credentials.settings.networks, 'uport.credentials.settings.networks includes 0x5').to.be.true
     })
 
     it('throws error if the network config object is not well formed ', () => {
@@ -110,9 +110,9 @@ describe('ConnectCore', () => {
       const uriHandler = sinon.spy(), closeUriHandler = sinon.spy()
       const uport = new ConnectCore('UportTests', {uriHandler, closeUriHandler})
       return uport.request({topic: mockTopic(), uri}).then(response => {
-        expect(response).to.equal(UPORT_ID)
-        expect(uriHandler.calledWith(uri)).to.be.true
-        expect(closeUriHandler.called).to.be.true
+        expect(response, 'uport.request response').to.equal(UPORT_ID)
+        expect(uriHandler.calledWith(uri), uriHandler.lastCall.args[0]).to.be.true
+        expect(closeUriHandler.called, 'closeUriHandler called').to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -122,8 +122,8 @@ describe('ConnectCore', () => {
       const uriHandler = sinon.spy()
       const uport = new ConnectCore('UportTests', { uriHandler })
       return uport.request({topic: mockTopic(), uri}).then(response => {
-        expect(response).to.equal(UPORT_ID)
-        expect(uriHandler.calledWith(uri)).to.be.true
+        expect(response, 'uport.request response').to.equal(UPORT_ID)
+        expect(uriHandler.calledWith(uri), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
           throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -138,9 +138,9 @@ describe('ConnectCore', () => {
         uriHandler
       }).then(response => {
         expect(response).to.equal(UPORT_ID)
-        expect(uriHandler.calledWith(uri)).to.be.true
-        expect(closeUriHandler.called).to.be.false
-        expect(uriHandlerDefault.called).to.be.false
+        expect(uriHandler.calledWith(uri), uriHandler.lastCall.args[0]).to.be.true
+        expect(closeUriHandler.called, 'closeUriHandler called').to.be.false
+        expect(uriHandlerDefault.called, 'default uriHandler called').to.be.false
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -151,8 +151,8 @@ describe('ConnectCore', () => {
       const uport = new ConnectCore('UportTests', { isMobile: true, mobileUriHandler })
       return uport.request({ uri, topic: mockTopic()})
         .then(response => {
-          expect(response).to.equal(UPORT_ID)
-          expect(mobileUriHandler.calledWith(uri)).to.be.true
+          expect(response, 'uport.request response').to.equal(UPORT_ID)
+          expect(mobileUriHandler.calledWith(uri), mobileUriHandler.lastCall.args[0]).to.be.true
         }, error => {
           throw new Error('uport.request Promise rejected, expected it to resolve')
         })
@@ -166,9 +166,9 @@ describe('ConnectCore', () => {
         topic: mockTopic(),
         uriHandler
       }).then(response => {
-        expect(response).to.equal(UPORT_ID)
-        expect(mobileUriHandler.calledWith(uri)).to.be.true
-        expect(uriHandler.called).to.be.false
+        expect(response, 'uport.request response').to.equal(UPORT_ID)
+        expect(mobileUriHandler.calledWith(uri), mobileUriHandler.lastCall.args[0]).to.be.true
+        expect(uriHandler.called, 'uriHandler called').to.be.false
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -180,8 +180,8 @@ describe('ConnectCore', () => {
       return uport.request({topic: errorTopic(), uri}).then(response => {
         throw new Error('uport.request Promise resolved, expected it to reject')
       }, error => {
-          expect(uriHandler.called).to.be.truef
-          expect(closeUriHandler.called).to.be.true
+          expect(uriHandler.called, 'uriHandler called').to.be.truef
+          expect(closeUriHandler.called, 'cloeUriHandler called').to.be.true
       })
     })
 
@@ -191,7 +191,7 @@ describe('ConnectCore', () => {
       const pushFunc = sinon.stub(uport.credentials, 'push');
 
       return uport.request({topic: mockTopic(), uri}).then(response => {
-        expect(pushFunc.calledOnce).to.be.true
+        expect(pushFunc.calledOnce, 'uport.credentials.push called').to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -204,8 +204,8 @@ describe('ConnectCore', () => {
       const uriHandlerFunc = sinon.stub(uport, 'uriHandler')
 
       return uport.request({topic: mockTopic(), uri}).then(response => {
-        expect(pushFunc.calledOnce).to.be.true
-        expect(uriHandlerFunc.notCalled).to.be.true
+        expect(pushFunc.calledOnce, 'uport.credentials.push called').to.be.true
+        expect(uriHandlerFunc.called, 'uriHandler called').to.be.false
       }, error => {
           throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -219,7 +219,7 @@ describe('ConnectCore', () => {
         const uport = new ConnectCore('UportTests', {
           clientId: CLIENT_ID,
           topicFactory: (name) => {
-            expect(name).to.equal('access_token')
+            expect(name, 'topic name').to.equal('access_token')
             return mockTopic(CREDENTIALS_JWT)
           },
           uriHandler,
@@ -230,8 +230,8 @@ describe('ConnectCore', () => {
         })
         expect(uport.canSign).to.be.false
         return uport.requestCredentials().then(profile => {
-          expect(uriHandler.calledWith(`me.uport:me?label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`)).to.be.true
-          expect(profile).to.equal(PROFILE)
+          expect(uriHandler.calledWith(`me.uport:me?label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`), uriHandler.lastCall.args[0]).to.be.true
+          expect(profile, 'uport.requestCredentials profile').to.equal(PROFILE)
         }, error => {
           throw new Error('uport.request Promise rejected, expected it to resolve')
         })
@@ -239,7 +239,7 @@ describe('ConnectCore', () => {
 
       it('throws error when requesting specific credentials', () => {
         const uport = new ConnectCore('UportTests')
-        expect(uport.canSign).to.be.false
+        expect(uport.canSign, 'uport.canSign').to.be.false
         return uport.requestCredentials({requested: ['phone']}).then(profile => {
           throw new Error('uport.request Promise resolved, expected it to reject')
         }, error => {
@@ -249,7 +249,7 @@ describe('ConnectCore', () => {
 
       it('throws error when requesting notifications', () => {
         const uport = new ConnectCore('UportTests')
-        expect(uport.canSign).to.be.false
+        expect(uport.canSign, 'uport.canSign').to.be.false
         return uport.requestCredentials({ notifications: true }).then(profile => {
           throw new Error('uport.request Promise resolved, expected it to reject')
         }, error => {
@@ -264,7 +264,7 @@ describe('ConnectCore', () => {
         const uport = new ConnectCore('UportTests', {
           clientId: CLIENT_ID,
           topicFactory: (name) => {
-            expect(name).to.equal('access_token')
+            expect(name, 'topic name').to.equal('access_token')
             return mockTopic(CREDENTIALS_JWT)
           },
           uriHandler,
@@ -282,8 +282,8 @@ describe('ConnectCore', () => {
         })
         expect(uport.canSign).to.be.true
         return uport.requestCredentials().then(profile => {
-          expect(profile).to.equal(PROFILE)
-          expect(uriHandler.calledWith(`me.uport:me?requestToken=${REQUEST_TOKEN}`)).to.be.true
+          expect(profile, 'uport.requestCredentials profile').to.equal(PROFILE)
+          expect(uriHandler.calledWith(`me.uport:me?requestToken=${REQUEST_TOKEN}`), uriHandler.lastCall.args[0]).to.be.true
         }, error => {
           throw new Error('uport.request Promise rejected, expected it to resolve')
         })
@@ -295,7 +295,7 @@ describe('ConnectCore', () => {
       const uport = new ConnectCore('UportTests', {
         clientId: CLIENT_ID,
         topicFactory: (name) => {
-          expect(name).to.equal('access_token')
+          expect(name, 'topic name').to.equal('access_token')
           return mockTopic(CREDENTIALS_JWT)
         },
         uriHandler,
@@ -317,7 +317,7 @@ describe('ConnectCore', () => {
       })
       expect(uport.canSign).to.be.true
       return uport.requestCredentials({requested: ['phone'], notifications: true}).then(profile => {
-        expect(profile).to.equal(PROFILE)
+        expect(profile,  'uport.requestCredentials profile').to.equal(PROFILE)
         expect(uriHandler.calledWith(`me.uport:me?requestToken=${REQUEST_TOKEN}`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
@@ -329,7 +329,7 @@ describe('ConnectCore', () => {
       const uport = new ConnectCore('UportTests', {
         clientId: CLIENT_ID,
         topicFactory: (name) => {
-          expect(name).to.equal('access_token')
+          expect(name, 'topic name').to.equal('access_token')
           return mockTopic(CREDENTIALS_JWT)
         },
         uriHandler,
@@ -349,7 +349,7 @@ describe('ConnectCore', () => {
           })
       })
       return uport.requestCredentials({notifications: true}).then(res => {
-        expect(uport.pushToken).to.equal(PUSH_TOKEN)
+        expect(uport.pushToken, 'uport.pushToken').to.equal(PUSH_TOKEN)
         expect(res).to.be.deep.equal({...PROFILE, pushToken: PUSH_TOKEN})
         expect(uriHandler.calledWith(`me.uport:me?requestToken=${REQUEST_TOKEN}`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
@@ -364,7 +364,7 @@ describe('ConnectCore', () => {
       const uport = new ConnectCore('UportTests', {
         clientId: CLIENT_ID,
         topicFactory: (name) => {
-          expect(name).to.equal('access_token')
+          expect(name, 'topic name').to.equal('access_token')
           return mockTopic(CREDENTIALS_JWT)
         },
         uriHandler,
@@ -374,8 +374,8 @@ describe('ConnectCore', () => {
         })
       })
       return uport.requestAddress().then(address => {
-        expect(address).to.equal(UPORT_ID)
-        expect(uriHandler.calledWith(`me.uport:me?label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`)).to.be.true
+        expect(address, 'uport.requestAddress address').to.equal(UPORT_ID)
+        expect(uriHandler.calledWith(`me.uport:me?label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -387,7 +387,7 @@ describe('ConnectCore', () => {
        const netConfig = { id: '0x5', registry: '0xab6c9051b9a1eg1abc1250f8b0640848c8ebfcg6', rpcUrl: 'https://somenet.io' }
        const uport = new ConnectCore('test app', {network: netConfig})
        const provider = uport.getProvider()
-       expect(uport.network.rpcUrl).to.equal(provider.provider.host)
+       expect(uport.network.rpcUrl, 'uport.network.rpcUrl').to.equal(provider.provider.host)
      })
   })
 
@@ -398,7 +398,7 @@ describe('ConnectCore', () => {
       const uriHandler = sinon.spy()
       const uport = new ConnectCore('UportTests', {
         topicFactory: (name) => {
-          expect(name).to.equal('status')
+          expect(name, 'topic name').to.equal('status')
           return mockTopic('ok')
         },
         uriHandler,
@@ -408,8 +408,8 @@ describe('ConnectCore', () => {
         })
       })
       return uport.attestCredentials(PAYLOAD).then((result) => {
-        expect(result).to.equal('ok')
-        expect(uriHandler.calledWith(`me.uport:add?attestations=${ATTESTATION}&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123`)).to.be.true
+        expect(result, 'uport.attestCredentials response').to.equal('ok')
+        expect(uriHandler.calledWith(`me.uport:add?attestations=${ATTESTATION}&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -429,8 +429,8 @@ describe('ConnectCore', () => {
         closeUriHandler: () => null
       })
       return uport.sendTransaction({to: CONTRACT, value: '0xff'}).then(txhash => {
-        expect(txhash).to.equal(FAKETX)
-        expect(uriHandler.calledWith(`me.uport:357XsqkPE3Mu1eRFZvD4xV3c2yCJr6jPnWZ?value=255&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`)).to.be.true
+        expect(txhash, 'uport.sendTransaction txhash').to.equal(FAKETX)
+        expect(uriHandler.calledWith(`me.uport:2oRMMSWkzMKpqkWpBxr5Xa9zMRXG4QBzJYM?value=255&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -454,10 +454,10 @@ describe('ConnectCore', () => {
         gas: '0x4444',
         function: `transfer(address ${UPORT_ID},uint 12312)`
       }).then(txhash => {
-        expect(txhash).to.equal(FAKETX)
+        expect(txhash, 'uport.sendTransaction txhash').to.equal(FAKETX)
         // Note it intentionally leaves out data as function overrides it
         // gas is not included in uri
-        expect(uriHandler.calledWith(`me.uport:357XsqkPE3Mu1eRFZvD4xV3c2yCJr6jPnWZ?value=255&function=transfer(address%200x3b2631d8e15b145fd2bf99fc5f98346aecdc394c%2Cuint%2012312)&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=0xa19320ce2f72768054ac01248734c7d4f9929f6d`)).to.be.true
+        expect(uriHandler.calledWith(`me.uport:2oRMMSWkzMKpqkWpBxr5Xa9zMRXG4QBzJYM?value=255&function=transfer(address%200x3b2631d8e15b145fd2bf99fc5f98346aecdc394c%2Cuint%2012312)&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=0xa19320ce2f72768054ac01248734c7d4f9929f6d`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -480,15 +480,15 @@ describe('ConnectCore', () => {
         data: 'abcdef01',
         gas: '0x4444'
       }).then(txhash => {
-        expect(txhash).to.equal('FAKETX')
-        expect(uriHandler.calledWith(`me.uport:357XsqkPE3Mu1eRFZvD4xV3c2yCJr6jPnWZ?value=255&bytecode=abcdef01&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`)).to.be.true
+        expect(txhash, 'uport.sendTransaction txhash').to.equal('FAKETX')
+        expect(uriHandler.calledWith(`me.uport:2oRMMSWkzMKpqkWpBxr5Xa9zMRXG4QBzJYM?value=255&bytecode=abcdef01&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
 
     it('throws an error for contract transactions', () => {
-      const uriHandler, closeUriHandler = sinon.spy()
+      const uriHandler = sinon.spy(), closeUriHandler = sinon.spy()
       const uport = new ConnectCore('UportTests', { uriHandler, closeUriHandler })
       expect(
         () => uport.sendTransaction({
@@ -528,7 +528,7 @@ describe('ConnectCore', () => {
       const uport = new ConnectCore('UportTests', {
         clientId: CLIENT_ID,
         topicFactory: (name) => {
-          expect(name).to.equal('tx')
+          expect(name, 'topic name').to.equal('tx')
           return mockTopic(FAKETX)
         },
         uriHandler,
@@ -537,8 +537,8 @@ describe('ConnectCore', () => {
       const contract = uport.contract(miniTokenABI)
       const token = contract.at('0x819320ce2f72768054ac01248734c7d4f9929f6c')
       return token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312).then(txhash => {
-        expect(txhash).to.equal(FAKETX)
-        expect(uriHandler.calledWith(`me.uport:357XsqkPE3Mu1eRFZvD4xV3c2yCJr6jPnWZ?function=transfer(address%200x3b2631d8e15b145fd2bf99fc5f98346aecdc394c%2C%20uint256%2012312)&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=0xa19320ce2f72768054ac01248734c7d4f9929f6d`)).to.be.true
+        expect(txhash, 'token.transfer txhash').to.equal(FAKETX)
+        expect(uriHandler.calledWith(`me.uport:2oRMMSWkzMKpqkWpBxr5Xa9zMRXG4QBzJYM?function=transfer(address%200x3b2631d8e15b145fd2bf99fc5f98346aecdc394c%2C%20uint256%2012312)&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=0xa19320ce2f72768054ac01248734c7d4f9929f6d`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -549,15 +549,15 @@ describe('ConnectCore', () => {
       const uport = new ConnectCore('UportTests', {
         clientId: CLIENT_ID,
         topicFactory: (name) => {
-          expect(name).to.equal('tx')
+          expect(name, 'topic name').to.equal('tx')
           return mockTopic(FAKETX)
         },
         closeUriHandler
       })
       const token = uport.contract(miniTokenABI).at('0x819320ce2f72768054ac01248734c7d4f9929f6c')
       return token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312, overideUriHandler).then(txhash => {
-        expect(txhash).to.equal(FAKETX)
-        expect(overideUriHandler.calledWith(`me.uport:357XsqkPE3Mu1eRFZvD4xV3c2yCJr6jPnWZ?function=transfer(address%200x3b2631d8e15b145fd2bf99fc5f98346aecdc394c%2C%20uint256%2012312)&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=0xa19320ce2f72768054ac01248734c7d4f9929f6d`)).to.be.true
+        expect(txhash, 'token.transfer txhash').to.equal(FAKETX)
+        expect(overideUriHandler.calledWith(`me.uport:2oRMMSWkzMKpqkWpBxr5Xa9zMRXG4QBzJYM?function=transfer(address%200x3b2631d8e15b145fd2bf99fc5f98346aecdc394c%2C%20uint256%2012312)&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=0xa19320ce2f72768054ac01248734c7d4f9929f6d`), overideUriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -566,7 +566,7 @@ describe('ConnectCore', () => {
     it('MNID encodes contract addresses in requests', () => {
      const uport = new ConnectCore('UportTests')
      const sendTransaction = sinon.stub(uport, 'request').callsFake(({uri}) => {
-       expect(uri).to.match(/357XsqkPE3Mu1eRFZvD4xV3c2yCJr6jPnWZ/)
+       expect(uri, 'request consumes uri').to.match(/2oRMMSWkzMKpqkWpBxr5Xa9zMRXG4QBzJYM/)
      });
      const token = uport.contract(miniTokenABI).at('0x819320ce2f72768054ac01248734c7d4f9929f6c')
      return token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312)

--- a/test/ConnectCore.js
+++ b/test/ConnectCore.js
@@ -99,7 +99,7 @@ describe('ConnectCore', () => {
 
     it('throws error if the network config object is not well formed ', () => {
        try { new ConnectCore('test app', {network: {id: '0x5'}}) } catch (e) { return  }
-       assert.fail()
+       throw new Error('did not throw error')
     })
   })
 
@@ -120,7 +120,7 @@ describe('ConnectCore', () => {
         expect(opened).to.equal(true)
         expect(closed).to.equal(true)
       }, error => {
-        assert.fail()
+        throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
 
@@ -136,7 +136,7 @@ describe('ConnectCore', () => {
         expect(response).to.equal(UPORT_ID)
         expect(opened).to.equal(true)
       }, error => {
-        assert.fail()
+          throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
 
@@ -144,7 +144,7 @@ describe('ConnectCore', () => {
       let opened, closed = false
       const uport = new ConnectCore('UportTests', {
         uriHandler: (_uri) => {
-          assert.fail()
+          throw new Error('uriHandler called, expect uriHandler to not be called')
         },
         closeUriHandler: () => { closed = true }
       })
@@ -160,7 +160,7 @@ describe('ConnectCore', () => {
         expect(opened).to.equal(true)
         expect(closed).to.equal(true)
       }, error => {
-        assert.fail()
+        throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
 
@@ -180,7 +180,7 @@ describe('ConnectCore', () => {
         expect(response).to.equal(UPORT_ID)
         expect(opened).to.equal(true)
       }, error => {
-        assert.fail()
+        throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
 
@@ -197,13 +197,13 @@ describe('ConnectCore', () => {
         uri,
         topic: mockTopic(),
         uriHandler: (_uri) => {
-          assert.fail()
+          throw new Error('uriHandler called, expect uriHandler to not be called')
         }
       }).then(response => {
         expect(response).to.equal(UPORT_ID)
         expect(opened).to.equal(true)
       }, error => {
-        assert.fail()
+        throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
 
@@ -217,7 +217,7 @@ describe('ConnectCore', () => {
         closeUriHandler: () => { closed = true }
       })
       return uport.request({topic: errorTopic(), uri}).then(response => {
-        assert.fail()
+        throw new Error('uport.request Promise resolved, expected it to reject')
       }, error => {
         expect(error.message).to.equal('It broke')
         expect(opened).to.equal(true)
@@ -234,7 +234,7 @@ describe('ConnectCore', () => {
       return uport.request({topic: mockTopic(), uri}).then(response => {
         expect(pushFunc.calledOnce).to.be.true
       }, error => {
-        assert.fail()
+        throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
 
@@ -248,7 +248,7 @@ describe('ConnectCore', () => {
         expect(pushFunc.calledOnce).to.be.true
         expect(uriHandlerFunc.notCalled).to.be.true
       }, error => {
-        assert.fail()
+          throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
   })
@@ -274,7 +274,7 @@ describe('ConnectCore', () => {
         return uport.requestCredentials().then(profile => {
           expect(profile).to.equal(PROFILE)
         }, error => {
-          assert.fail()
+          throw new Error('uport.request Promise rejected, expected it to resolve')
         })
       })
 
@@ -282,7 +282,7 @@ describe('ConnectCore', () => {
         const uport = new ConnectCore('UportTests')
         expect(uport.canSign).to.be.false
         return uport.requestCredentials({requested: ['phone']}).then(profile => {
-          assert.fail()
+          throw new Error('uport.request Promise resolved, expected it to reject')
         }, error => {
           expect(error.message).to.equal('Specific data can not be requested without a signer configured')
         })
@@ -292,7 +292,7 @@ describe('ConnectCore', () => {
         const uport = new ConnectCore('UportTests')
         expect(uport.canSign).to.be.false
         return uport.requestCredentials({ notifications: true }).then(profile => {
-          assert.fail()
+          throw new Error('uport.request Promise resolved, expected it to reject')
         }, error => {
           expect(error.message).to.equal('Notifications rights can not currently be requested without a signer configured')
         })
@@ -326,7 +326,7 @@ describe('ConnectCore', () => {
         return uport.requestCredentials().then(profile => {
           expect(profile).to.equal(PROFILE)
         }, error => {
-          assert.fail()
+          throw new Error('uport.request Promise rejected, expected it to resolve')
         })
       })
     })
@@ -364,7 +364,7 @@ describe('ConnectCore', () => {
         expect(profile).to.equal(PROFILE)
       }, error => {
         expect(error.message).to.equal('Specific data can not be requested without a signer configured')
-        assert.fail()
+        throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
 
@@ -397,7 +397,7 @@ describe('ConnectCore', () => {
         expect(uport.pushToken).to.equal(PUSH_TOKEN)
         expect(res).to.be.deep.equal({...PROFILE, pushToken: PUSH_TOKEN})
       }, error => {
-        assert.fail()
+        throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
   })
@@ -421,7 +421,7 @@ describe('ConnectCore', () => {
       return uport.requestAddress().then(address => {
         expect(address).to.equal(UPORT_ID)
       }, error => {
-        assert.fail()
+        throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
   })
@@ -458,7 +458,7 @@ describe('ConnectCore', () => {
         expect(result).to.equal('ok')
         expect(opened).to.be.true
       }, error => {
-        assert.fail()
+        throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
   })
@@ -479,7 +479,7 @@ describe('ConnectCore', () => {
       return uport.sendTransaction({to: CONTRACT, value: '0xff'}).then(txhash => {
         expect(txhash).to.equal(FAKETX)
       }, error => {
-        assert.fail()
+        throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
 
@@ -506,7 +506,7 @@ describe('ConnectCore', () => {
       }).then(txhash => {
         expect(txhash).to.equal(FAKETX)
       }, error => {
-        assert.fail()
+        throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
 
@@ -531,7 +531,7 @@ describe('ConnectCore', () => {
       }).then(txhash => {
         expect(txhash).to.equal('FAKETX')
       }, error => {
-        assert.fail()
+        throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
 
@@ -590,7 +590,7 @@ describe('ConnectCore', () => {
       return token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312).then(txhash => {
         expect(txhash).to.equal(FAKETX)
       }, error => {
-        assert.fail()
+        throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
 
@@ -612,7 +612,7 @@ describe('ConnectCore', () => {
       return token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312, overideUriHandler).then(txhash => {
         expect(txhash).to.equal(FAKETX)
       }, error => {
-        assert.fail()
+        throw new Error('uport.request Promise rejected, expected it to resolve')
       })
     })
 

--- a/test/ConnectCore.js
+++ b/test/ConnectCore.js
@@ -94,11 +94,11 @@ describe('ConnectCore', () => {
       const netConfig = { id: '0x5', registry: '0xab6c9051b9a1eg1abc1250f8b0640848c8ebfcg6', rpcUrl: 'https://somenet.io' }
       const uport = new ConnectCore('test app', {network: netConfig})
       expect(uport.network.id).to.equal('0x5')
-       expect('0x5' in uport.credentials.settings.networks).to.equal(true)
+      expect('0x5' in uport.credentials.settings.networks).to.equal(true)
     })
 
-    it('throws error if the network config object is not well formed ', (done) => {
-       try { new ConnectCore('test app', {network: {id: '0x5'}}) } catch (e) { done() }
+    it('throws error if the network config object is not well formed ', () => {
+       try { new ConnectCore('test app', {network: {id: '0x5'}}) } catch (e) { return  }
        assert.fail()
     })
   })
@@ -106,8 +106,8 @@ describe('ConnectCore', () => {
   describe('request', () => {
     const uri = 'me.uport:me'
 
-    it('defaults to the preset uriHandler', (done) => {
-      let opened, closed
+    it('defaults to the preset uriHandler', () => {
+      let opened, closed = false
       const uport = new ConnectCore('UportTests', {
         uriHandler: (_uri) => {
           expect(_uri).to.equal(uri)
@@ -115,45 +115,40 @@ describe('ConnectCore', () => {
         },
         closeUriHandler: () => { closed = true }
       })
-      uport.request({topic: mockTopic(), uri}).then(response => {
+      return uport.request({topic: mockTopic(), uri}).then(response => {
         expect(response).to.equal(UPORT_ID)
         expect(opened).to.equal(true)
         expect(closed).to.equal(true)
-        done()
       }, error => {
         assert.fail()
-        done()
       })
     })
 
-    it('works fine without a closeUriHandler', (done) => {
-      let opened
+    it('works fine without a closeUriHandler', () => {
+      let opened = false
       const uport = new ConnectCore('UportTests', {
         uriHandler: (_uri) => {
           expect(_uri).to.equal(uri)
           opened = true
         }
       })
-      uport.request({topic: mockTopic(), uri}).then(response => {
+      return uport.request({topic: mockTopic(), uri}).then(response => {
         expect(response).to.equal(UPORT_ID)
         expect(opened).to.equal(true)
-        done()
       }, error => {
         assert.fail()
-        done()
       })
     })
 
-    it('can be overriden by a passed in uriHandler', (done) => {
-      let opened, closed = false;
+    it('can be overriden by a passed in uriHandler', () => {
+      let opened, closed = false
       const uport = new ConnectCore('UportTests', {
         uriHandler: (_uri) => {
           assert.fail()
-          done()
         },
         closeUriHandler: () => { closed = true }
       })
-      uport.request({
+      return uport.request({
         uri,
         topic: mockTopic(),
         uriHandler: (_uri) => {
@@ -163,15 +158,13 @@ describe('ConnectCore', () => {
       }).then(response => {
         expect(response).to.equal(UPORT_ID)
         expect(opened).to.equal(true)
-        expect(closed).to.equal(false)
-        done()
+        expect(closed).to.equal(true)
       }, error => {
         assert.fail()
-        done()
       })
     })
 
-    it('uses the preset mobileUriHandler', (done) => {
+    it('uses the preset mobileUriHandler', () => {
       let opened, closed
       const uport = new ConnectCore('UportTests', {
         isMobile: true,
@@ -180,21 +173,19 @@ describe('ConnectCore', () => {
           opened = true
         }
       })
-      uport.request({
+      return uport.request({
         uri,
         topic: mockTopic()
       }).then(response => {
         expect(response).to.equal(UPORT_ID)
         expect(opened).to.equal(true)
-        done()
       }, error => {
         assert.fail()
-        done()
       })
     })
 
-    it('uses the preset mobileUriHandler even if there is a local override', (done) => {
-      let opened, closed
+    it('uses the preset mobileUriHandler even if there is a local override', () => {
+      let opened, closed = false
       const uport = new ConnectCore('UportTests', {
         isMobile: true,
         mobileUriHandler: (_uri) => {
@@ -202,25 +193,22 @@ describe('ConnectCore', () => {
           opened = true
         }
       })
-      uport.request({
+      return uport.request({
         uri,
         topic: mockTopic(),
         uriHandler: (_uri) => {
           assert.fail()
-          done()
         }
       }).then(response => {
         expect(response).to.equal(UPORT_ID)
         expect(opened).to.equal(true)
-        done()
       }, error => {
         assert.fail()
-        done()
       })
     })
 
-    it('remembers to close if there is an error on the topic', (done) => {
-      let opened, closed
+    it('remembers to close if there is an error on the topic', () => {
+      let opened, closed = false
       const uport = new ConnectCore('UportTests', {
         uriHandler: (_uri) => {
           expect(_uri).to.equal(uri)
@@ -228,58 +216,49 @@ describe('ConnectCore', () => {
         },
         closeUriHandler: () => { closed = true }
       })
-      uport.request({topic: errorTopic(), uri}).then(response => {
+      return uport.request({topic: errorTopic(), uri}).then(response => {
         assert.fail()
-        done()
       }, error => {
         expect(error.message).to.equal('It broke')
         expect(opened).to.equal(true)
         expect(closed).to.equal(true)
-        done()
       })
     })
 
-    it('sends a push notification if push token is available', (done) => {
+    it('sends a push notification if push token is available', () => {
 
       const uport = new ConnectCore('UportTests')
       uport.pushToken = '12345'
       const pushFunc = sinon.stub(uport.credentials, 'push');
 
-      uport.request({topic: mockTopic(), uri}).then(response => {
+      return uport.request({topic: mockTopic(), uri}).then(response => {
         expect(pushFunc.calledOnce).to.be.true
-        done()
       }, error => {
         assert.fail()
-        done()
       })
     })
 
-    it('does not call default uriHandler if push notification sent', (done) => {
+    it('does not call default uriHandler if push notification sent', () => {
       const uport = new ConnectCore('UportTests')
       uport.pushToken = '12345'
       const pushFunc = sinon.stub(uport.credentials, 'push');
       const uriHandlerFunc = sinon.stub(uport, 'uriHandler')
 
-      uport.request({topic: mockTopic(), uri}).then(response => {
+      return uport.request({topic: mockTopic(), uri}).then(response => {
         expect(pushFunc.calledOnce).to.be.true
-        console.log(uriHandlerFunc)
         expect(uriHandlerFunc.notCalled).to.be.true
-        done()
       }, error => {
         assert.fail()
-        done()
       })
     })
   })
 
   describe('requestCredentials', () => {
     describe('without signer', () => {
-      it('requests public profile', (done) => {
-        // TODO This tests fails
+      it('requests public profile', () => {
         const uport = new ConnectCore('UportTests', {
           clientId: CLIENT_ID,
           topicFactory: (name) => {
-            // TODO is called
             expect(name).to.equal('access_token')
             return mockTopic(CREDENTIALS_JWT)
           },
@@ -287,48 +266,41 @@ describe('ConnectCore', () => {
             expect(uri).to.equal(`me.uport:me?label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`)
           },
           credentials: mockVerifyingCredentials((jwt) => {
-            // TODO is called, why is this one false not true (isCredential)
             expect(jwt).to.equal(CREDENTIALS_JWT)
             return PROFILE
           })
         })
         expect(uport.canSign).to.be.false
-        uport.requestCredentials().then(profile => {
+        return uport.requestCredentials().then(profile => {
           expect(profile).to.equal(PROFILE)
-          done()
         }, error => {
           assert.fail()
-          done()
         })
       })
 
-      it('throws error when requesting specific credentials', (done) => {
+      it('throws error when requesting specific credentials', () => {
         const uport = new ConnectCore('UportTests')
         expect(uport.canSign).to.be.false
-        uport.requestCredentials({requested: ['phone']}).then(profile => {
+        return uport.requestCredentials({requested: ['phone']}).then(profile => {
           assert.fail()
-          done()
         }, error => {
           expect(error.message).to.equal('Specific data can not be requested without a signer configured')
-          done()
         })
       })
 
-      it('throws error when requesting notifications', (done) => {
+      it('throws error when requesting notifications', () => {
         const uport = new ConnectCore('UportTests')
         expect(uport.canSign).to.be.false
-        uport.requestCredentials({ notifications: true }).then(profile => {
+        return uport.requestCredentials({ notifications: true }).then(profile => {
           assert.fail()
-          done()
         }, error => {
           expect(error.message).to.equal('Notifications rights can not currently be requested without a signer configured')
-          done()
         })
       })
     })
 
     describe('with signer', () => {
-      it('requests public profile', (done) => {
+      it('requests public profile', () => {
         const uport = new ConnectCore('UportTests', {
           clientId: CLIENT_ID,
           topicFactory: (name) => {
@@ -351,18 +323,15 @@ describe('ConnectCore', () => {
             })
         })
         expect(uport.canSign).to.be.true
-        uport.requestCredentials().then(profile => {
+        return uport.requestCredentials().then(profile => {
           expect(profile).to.equal(PROFILE)
-          done()
         }, error => {
           assert.fail()
-          done()
         })
       })
     })
 
-    it('requests specific credentials', (done) => {
-      // TODO THIS tests fails
+    it('requests specific credentials', () => {
       const uport = new ConnectCore('UportTests', {
         clientId: CLIENT_ID,
         topicFactory: (name) => {
@@ -371,7 +340,7 @@ describe('ConnectCore', () => {
         },
         uriHandler: (uri) => {
           expect(uri).to.equal(`me.uport:me?requestToken=${REQUEST_TOKEN}`)
-          // TODO does this fail
+          // TODO
           // expect(uri).to.equal(`me.uport:me?requestToken=${REQUEST_TOKEN}&network_id=0x2a`)
         },
         credentials: mockSigningCredentials(
@@ -391,17 +360,15 @@ describe('ConnectCore', () => {
           })
       })
       expect(uport.canSign).to.be.true
-      uport.requestCredentials({requested: ['phone'], notifications: true}).then(profile => {
+      return uport.requestCredentials({requested: ['phone'], notifications: true}).then(profile => {
         expect(profile).to.equal(PROFILE)
-        done()
       }, error => {
         expect(error.message).to.equal('Specific data can not be requested without a signer configured')
         assert.fail()
-        done()
       })
     })
 
-    it('it saves a push notification token if push token is included in response', (done) => {
+    it('it saves a push notification token if push token is included in response', () => {
       const uport = new ConnectCore('UportTests', {
         clientId: CLIENT_ID,
         topicFactory: (name) => {
@@ -426,20 +393,17 @@ describe('ConnectCore', () => {
             }
           })
       })
-      uport.requestCredentials({notifications: true}).then(res => {
+      return uport.requestCredentials({notifications: true}).then(res => {
         expect(uport.pushToken).to.equal(PUSH_TOKEN)
         expect(res).to.be.deep.equal({...PROFILE, pushToken: PUSH_TOKEN})
-        done()
       }, error => {
         assert.fail()
-        done()
       })
     })
   })
 
   describe('requestAddress', () => {
-    it('returns address', (done) => {
-      // TODO  THIS test fails
+    it('returns address', () => {
       const uport = new ConnectCore('UportTests', {
         clientId: CLIENT_ID,
         topicFactory: (name) => {
@@ -454,12 +418,10 @@ describe('ConnectCore', () => {
           return PROFILE
         })
       })
-      uport.requestAddress().then(address => {
+      return uport.requestAddress().then(address => {
         expect(address).to.equal(UPORT_ID)
-        done()
       }, error => {
         assert.fail()
-        done()
       })
     })
   })
@@ -476,8 +438,8 @@ describe('ConnectCore', () => {
   describe('attestCredentials', () => {
     const ATTESTATION = 'ATTESTATION'
     const PAYLOAD = {sub: '0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', claim: { name: 'Bob' }, exp: 123123123}
-    it('provides attestation to user using default uriHandler', (done) => {
-      let opened
+    it('provides attestation to user using default uriHandler', () => {
+      let opened = false
       const uport = new ConnectCore('UportTests', {
         topicFactory: (name) => {
           expect(name).to.equal('status')
@@ -492,19 +454,17 @@ describe('ConnectCore', () => {
           return ATTESTATION
         })
       })
-      uport.attestCredentials(PAYLOAD).then((result) => {
+      return uport.attestCredentials(PAYLOAD).then((result) => {
         expect(result).to.equal('ok')
         expect(opened).to.be.true
-        done()
       }, error => {
         assert.fail()
-        done()
       })
     })
   })
 
   describe('sendTransaction', () => {
-    it('shows simple value url', (done) => {
+    it('shows simple value url', () => {
       const uport = new ConnectCore('UportTests', {
         clientId: CLIENT_ID,
         topicFactory: (name) => {
@@ -516,16 +476,14 @@ describe('ConnectCore', () => {
         },
         closeUriHandler: () => null
       })
-      uport.sendTransaction({to: CONTRACT, value: '0xff'}).then(txhash => {
+      return uport.sendTransaction({to: CONTRACT, value: '0xff'}).then(txhash => {
         expect(txhash).to.equal(FAKETX)
-        done()
       }, error => {
         assert.fail()
-        done()
       })
     })
 
-    it('shows simple url with function', (done) => {
+    it('shows simple url with function', () => {
       const uport = new ConnectCore('UportTests', {
         clientId: CLIENT_ID,
         topicFactory: (name) => {
@@ -539,7 +497,7 @@ describe('ConnectCore', () => {
         },
         closeUriHandler: () => null
       })
-      uport.sendTransaction({
+      return uport.sendTransaction({
         to: CONTRACT,
         value: '0xff',
         data: 'abcdef01',
@@ -547,14 +505,12 @@ describe('ConnectCore', () => {
         function: `transfer(address ${UPORT_ID},uint 12312)`
       }).then(txhash => {
         expect(txhash).to.equal(FAKETX)
-        done()
       }, error => {
         assert.fail()
-        done()
       })
     })
 
-    it('shows simple url with data', (done) => {
+    it('shows simple url with data', () => {
       const uport = new ConnectCore('UportTests', {
         clientId: CLIENT_ID,
         topicFactory: (name) => {
@@ -567,17 +523,15 @@ describe('ConnectCore', () => {
         },
         closeUriHandler: () => null
       })
-      uport.sendTransaction({
+      return uport.sendTransaction({
         to: CONTRACT,
         value: '0xff',
         data: 'abcdef01',
         gas: '0x4444'
       }).then(txhash => {
         expect(txhash).to.equal('FAKETX')
-        done()
       }, error => {
         assert.fail()
-        done()
       })
     })
 
@@ -619,7 +573,7 @@ describe('ConnectCore', () => {
       'payable': false,
       'type': 'function'
     }]
-    it('shows correct uri to default uriHandler', (done) => {
+    it('shows correct uri to default uriHandler', () => {
       const uport = new ConnectCore('UportTests', {
         clientId: CLIENT_ID,
         topicFactory: (name) => {
@@ -633,16 +587,14 @@ describe('ConnectCore', () => {
       })
       const contract = uport.contract(miniTokenABI)
       const token = contract.at('0x819320ce2f72768054ac01248734c7d4f9929f6c')
-      token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312).then(txhash => {
+      return token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312).then(txhash => {
         expect(txhash).to.equal(FAKETX)
-        done()
       }, error => {
         assert.fail()
-        done()
       })
     })
 
-    it('shows correct uri to overridden uriHandler', (done) => {
+    it('shows correct uri to overridden uriHandler', () => {
       const uport = new ConnectCore('UportTests', {
         clientId: CLIENT_ID,
         topicFactory: (name) => {
@@ -657,23 +609,21 @@ describe('ConnectCore', () => {
       }
 
       const token = uport.contract(miniTokenABI).at('0x819320ce2f72768054ac01248734c7d4f9929f6c')
-      token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312, overideUriHandler).then(txhash => {
+      return token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312, overideUriHandler).then(txhash => {
         expect(txhash).to.equal(FAKETX)
-        done()
       }, error => {
         assert.fail()
-        done()
       })
     })
 
-    it('MNID encodes contract addresses in requests', (done) => {
+    it('MNID encodes contract addresses in requests', () => {
      const uport = new ConnectCore('UportTests')
      const sendTransaction = sinon.stub(uport, 'request').callsFake(({uri}) => {
-       expect(uri).to.match(/2oRMMSWkzMKpqkWpBxr5Xa9zMRXG4QBzJYM/)
-       done()
+      //  TODO
+       expect(uri).to.match(/357XsqkPE3Mu1eRFZvD4xV3c2yCJr6jPnWZ/)
      });
      const token = uport.contract(miniTokenABI).at('0x819320ce2f72768054ac01248734c7d4f9929f6c')
-     token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312)
+     return token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312)
    })
 
    it('accepts contracts at both addresses and MNID encoded adresses', () => {

--- a/test/uportWeb3.js
+++ b/test/uportWeb3.js
@@ -108,9 +108,7 @@ describe('uportWeb3 integration tests', function () {
     status.updateStatus(coolStatus, (err, res) => {
       expect(err).to.be.null
       if (err) {
-        console.log(err.message)
-        assert.fail()
-        return done()
+        throw new Error(`Expected updateStatus to not return error: ${err.message}`)
       }
       expect(res).to.be
       web3.eth.getTransactionReceipt(res, (err, tx) => {


### PR DESCRIPTION
- mocha handles promises well, return promises instead of using async done() otherwise some errors may not surface and the promise may not resolve or reject 
- add tests spies to be sure all expect/assert statements are evaluated, some where in functions which were not called. 
- Improve readability/usefulness of test output, replace assert.fail with errors messages and pass descriptive strings to expect