### PR TITLE
Disabled push notifications when in a mobile browser

### DIFF
--- a/src/ConnectCore.js
+++ b/src/ConnectCore.js
@@ -214,7 +214,7 @@ class ConnectCore {
 
     if (defaultUriHandler) { uriHandler = this.uriHandler }
 
-    if (this.pushToken) {
+    if (this.pushToken && !this.isOnMobile) {
       this.credentials.push(this.pushToken, {url: uri})
       return topic
     }

--- a/test/ConnectCore.js
+++ b/test/ConnectCore.js
@@ -180,7 +180,7 @@ describe('ConnectCore', () => {
       return uport.request({topic: errorTopic(), uri}).then(response => {
         throw new Error('uport.request Promise resolved, expected it to reject')
       }, error => {
-        expect(uriHandler.called, 'uriHandler called').to.be.truef
+        expect(uriHandler.called, 'uriHandler called').to.be.true
         expect(closeUriHandler.called, 'cloeUriHandler called').to.be.true
       })
     })
@@ -192,6 +192,21 @@ describe('ConnectCore', () => {
 
       return uport.request({topic: mockTopic(), uri}).then(response => {
         expect(pushFunc.calledOnce, 'uport.credentials.push called').to.be.true
+      }, error => {
+        throw new Error('uport.request Promise rejected, expected it to resolve')
+      })
+    })
+
+    it('don\'t send a push notification if on mobile', () => {
+      const uport = new ConnectCore('UportTests')
+      uport.pushToken = '12345'
+      uport.isOnMobile = true
+      const pushFunc = sinon.stub(uport.credentials, 'push')
+      const uriHandler = sinon.spy()
+
+      return uport.request({topic: mockTopic(), uri, uriHandler }).then(response => {
+        expect(pushFunc.calledOnce, 'uport.credentials.push called').to.be.false
+        expect(uriHandler.called, 'uriHandler called').to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })


### PR DESCRIPTION
This solves a bug in which using uport-connect in a dapp in a mobile browser it sends you a push notification instead of redirecting you directly into the uport app.