### PR TITLE
docs: verified request object type for requestCredentials

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -197,7 +197,10 @@ Creates a request given a request object, will also always return the user's
  uPort address. Calls given uriHandler with the uri. Returns a promise to
  wait for the response.
 
- Supports request objects of type <code>{requested: [...]}</code> for ordinary requests and <code>{verified: [...]}</code> for requests that should retrieve full attestations, including a JWT containing the actual signature. If the issuer's public key is stored, this signature can be verified with jwt-js or jsonwebtoken.
+ Supports request objects of type {requested: [...]} for ordinary requests
+ and {verified: [...]} for requests that should retrieve full attestations,
+ including a JWT containing the actual signature. If the issuer's public key
+ is stored, this signature can be verified with jwt-js or jsonwebtoken.
 
 **Kind**: instance method of <code>[Connect](#Connect)</code>  
 **Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a response object or rejects with an error.  
@@ -216,7 +219,7 @@ const req = {requested: ['name', 'country']}
      ...
  })
 
-
+ 
 ```
 <a name="ConnectCore+requestAddress"></a>
 
@@ -261,7 +264,7 @@ const cred = {
    // response okay, received in uPort app
  })
 
-
+ 
 ```
 <a name="ConnectCore+request"></a>
 
@@ -324,7 +327,7 @@ const txobject = {
    ...
  })
 
-
+ 
 ```
 <a name="ConnectCore"></a>
 
@@ -392,6 +395,11 @@ Creates a request given a request object, will also always return the user's
  uPort address. Calls given uriHandler with the uri. Returns a promise to
  wait for the response.
 
+ Supports request objects of type {requested: [...]} for ordinary requests
+ and {verified: [...]} for requests that should retrieve full attestations,
+ including a JWT containing the actual signature. If the issuer's public key
+ is stored, this signature can be verified with jwt-js or jsonwebtoken.
+
 **Kind**: instance method of <code>[ConnectCore](#ConnectCore)</code>  
 **Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a response object or rejects with an error.  
 
@@ -409,7 +417,7 @@ const req = {requested: ['name', 'country']}
      ...
  })
 
-
+ 
 ```
 <a name="ConnectCore+requestAddress"></a>
 
@@ -454,7 +462,7 @@ const cred = {
    // response okay, received in uPort app
  })
 
-
+ 
 ```
 <a name="ConnectCore+request"></a>
 
@@ -517,7 +525,7 @@ const txobject = {
    ...
  })
 
-
+ 
 ```
 <a name="UportSubprovider"></a>
 
@@ -566,3 +574,4 @@ Overrides sendAsync to caputure the following RPC calls eth_coinbase, eth_accoun
 | --- | --- | --- |
 | payload | <code>Any</code> | request payload |
 | callback | <code>function</code> | called with response or error |
+

--- a/DOCS.md
+++ b/DOCS.md
@@ -197,6 +197,8 @@ Creates a request given a request object, will also always return the user's
  uPort address. Calls given uriHandler with the uri. Returns a promise to
  wait for the response.
 
+ Supports request objects of type <code>{requested: [...]}</code> for ordinary requests and <code>{verified: [...]}</code> for requests that should retrieve full attestations, including a JWT containing the actual signature. If the issuer's public key is stored, this signature can be verified with jwt-js or jsonwebtoken.
+
 **Kind**: instance method of <code>[Connect](#Connect)</code>  
 **Returns**: <code>Promise.&lt;Object, Error&gt;</code> - a promise which resolves with a response object or rejects with an error.  
 
@@ -214,7 +216,7 @@ const req = {requested: ['name', 'country']}
      ...
  })
 
- 
+
 ```
 <a name="ConnectCore+requestAddress"></a>
 
@@ -259,7 +261,7 @@ const cred = {
    // response okay, received in uPort app
  })
 
- 
+
 ```
 <a name="ConnectCore+request"></a>
 
@@ -322,7 +324,7 @@ const txobject = {
    ...
  })
 
- 
+
 ```
 <a name="ConnectCore"></a>
 
@@ -407,7 +409,7 @@ const req = {requested: ['name', 'country']}
      ...
  })
 
- 
+
 ```
 <a name="ConnectCore+requestAddress"></a>
 
@@ -452,7 +454,7 @@ const cred = {
    // response okay, received in uPort app
  })
 
- 
+
 ```
 <a name="ConnectCore+request"></a>
 
@@ -515,7 +517,7 @@ const txobject = {
    ...
  })
 
- 
+
 ```
 <a name="UportSubprovider"></a>
 
@@ -564,4 +566,3 @@ Overrides sendAsync to caputure the following RPC calls eth_coinbase, eth_accoun
 | --- | --- | --- |
 | payload | <code>Any</code> | request payload |
 | callback | <code>function</code> | called with response or error |
-

--- a/src/ConnectCore.js
+++ b/src/ConnectCore.js
@@ -114,6 +114,11 @@ class ConnectCore {
    *  uPort address. Calls given uriHandler with the uri. Returns a promise to
    *  wait for the response.
    *
+   *  Supports request objects of type {requested: [...]} for ordinary requests
+   *  and {verified: [...]} for requests that should retrieve full attestations,
+   *  including a JWT containing the actual signature. If the issuer's public key
+   *  is stored, this signature can be verified with jwt-js or jsonwebtoken. 
+   *
    *  @example
    *  const req = {requested: ['name', 'country']}
    *  connect.requestCredentials(req).then(credentials => {


### PR DESCRIPTION
As this was a crucial feature for our demo, but there seemed to be no documentation apart from @oed sharing it on Gitter. 