### PR TITLE
feat: add post opt to uri

### DIFF
--- a/src/ConnectCore.js
+++ b/src/ConnectCore.js
@@ -115,7 +115,7 @@ class ConnectCore {
    *  Creates a request given a request object, will also always return the user's
    *  uPort address. Calls given uriHandler with the uri. Returns a promise to
    *  wait for the response.
-   * 
+   *
    *  @example
    *  const req = { requested: ['name', 'country'], verified: ['GithubUser']}
    *  connect.requestCredentials(req).then(credentials => {
@@ -225,9 +225,12 @@ class ConnectCore {
     }
 
     // TODO consider UI for push notifications, maybe a popup explaining, then a loading symbol waiting for a response, a retry and a cancel button. should dev use uriHandler if using push notifications?
-    (this.isOnMobile && this.mobileUriHandler)
-      ? this.mobileUriHandler(uri)
-      : uriHandler(uri, topic.cancel, this.appName, this.firstReq)
+    if (this.isOnMobile && this.mobileUriHandler) {
+      this.mobileUriHandler(uri)
+    } else {
+      uri = (uri == 'me.uport:me') ? `${uri}?callback_type=post` : `${uri}&callback_type=post`
+      uriHandler(uri, topic.cancel, this.appName, this.firstReq)  
+    }
 
     this.firstReq = false
 

--- a/test/ConnectCore.js
+++ b/test/ConnectCore.js
@@ -111,7 +111,7 @@ describe('ConnectCore', () => {
       const uport = new ConnectCore('UportTests', {uriHandler, closeUriHandler})
       return uport.request({topic: mockTopic(), uri}).then(response => {
         expect(response, 'uport.request response').to.equal(UPORT_ID)
-        expect(uriHandler.calledWith(uri), uriHandler.lastCall.args[0]).to.be.true
+        expect(uriHandler.calledWith('me.uport:me?callback_type=post'), uriHandler.lastCall.args[0]).to.be.true
         expect(closeUriHandler.called, 'closeUriHandler called').to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
@@ -123,7 +123,7 @@ describe('ConnectCore', () => {
       const uport = new ConnectCore('UportTests', { uriHandler })
       return uport.request({topic: mockTopic(), uri}).then(response => {
         expect(response, 'uport.request response').to.equal(UPORT_ID)
-        expect(uriHandler.calledWith(uri), uriHandler.lastCall.args[0]).to.be.true
+        expect(uriHandler.calledWith('me.uport:me?callback_type=post'), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -138,7 +138,7 @@ describe('ConnectCore', () => {
         uriHandler
       }).then(response => {
         expect(response).to.equal(UPORT_ID)
-        expect(uriHandler.calledWith(uri), uriHandler.lastCall.args[0]).to.be.true
+        expect(uriHandler.calledWith('me.uport:me?callback_type=post'), uriHandler.lastCall.args[0]).to.be.true
         expect(closeUriHandler.called, 'closeUriHandler called').to.be.false
         expect(uriHandlerDefault.called, 'default uriHandler called').to.be.false
       }, error => {
@@ -245,7 +245,7 @@ describe('ConnectCore', () => {
         })
         expect(uport.canSign).to.be.false
         return uport.requestCredentials().then(profile => {
-          expect(uriHandler.calledWith(`me.uport:me?network_id=0x4&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`), uriHandler.lastCall.args[0]).to.be.true
+          expect(uriHandler.calledWith(`me.uport:me?network_id=0x4&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}&callback_type=post`), uriHandler.lastCall.args[0]).to.be.true
           expect(profile, 'uport.requestCredentials profile').to.equal(PROFILE)
         }, error => {
           throw new Error('uport.request Promise rejected, expected it to resolve')
@@ -298,7 +298,7 @@ describe('ConnectCore', () => {
         expect(uport.canSign).to.be.true
         return uport.requestCredentials().then(profile => {
           expect(profile, 'uport.requestCredentials profile').to.equal(PROFILE)
-          expect(uriHandler.calledWith(`me.uport:me?requestToken=${REQUEST_TOKEN}`), uriHandler.lastCall.args[0]).to.be.true
+          expect(uriHandler.calledWith(`me.uport:me?requestToken=${REQUEST_TOKEN}&callback_type=post`), uriHandler.lastCall.args[0]).to.be.true
         }, error => {
           throw new Error('uport.request Promise rejected, expected it to resolve')
         })
@@ -330,7 +330,7 @@ describe('ConnectCore', () => {
       expect(uport.canSign).to.be.true
       return uport.requestCredentials().then(profile => {
         expect(profile, 'uport.requestCredentials profile').to.equal(PROFILE)
-        expect(uriHandler.calledWith(`me.uport:me?requestToken=${REQUEST_TOKEN}`), uriHandler.lastCall.args[0]).to.be.true
+        expect(uriHandler.calledWith(`me.uport:me?requestToken=${REQUEST_TOKEN}&callback_type=post`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -365,7 +365,7 @@ describe('ConnectCore', () => {
       expect(uport.canSign).to.be.true
       return uport.requestCredentials({requested: ['phone'], notifications: true}).then(profile => {
         expect(profile, 'uport.requestCredentials profile').to.equal(PROFILE)
-        expect(uriHandler.calledWith(`me.uport:me?requestToken=${REQUEST_TOKEN}`), uriHandler.lastCall.args[0]).to.be.true
+        expect(uriHandler.calledWith(`me.uport:me?requestToken=${REQUEST_TOKEN}&callback_type=post`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -399,7 +399,7 @@ describe('ConnectCore', () => {
       return uport.requestCredentials({notifications: true}).then(res => {
         expect(uport.pushToken, 'uport.pushToken').to.equal(PUSH_TOKEN)
         expect(res).to.be.deep.equal({...PROFILE, pushToken: PUSH_TOKEN})
-        expect(uriHandler.calledWith(`me.uport:me?requestToken=${REQUEST_TOKEN}`), uriHandler.lastCall.args[0]).to.be.true
+        expect(uriHandler.calledWith(`me.uport:me?requestToken=${REQUEST_TOKEN}&callback_type=post`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -423,7 +423,7 @@ describe('ConnectCore', () => {
       })
       return uport.requestAddress().then(address => {
         expect(address, 'uport.requestAddress address').to.equal(UPORT_ID)
-        expect(uriHandler.calledWith(`me.uport:me?network_id=0x4&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`), uriHandler.lastCall.args[0]).to.be.true
+        expect(uriHandler.calledWith(`me.uport:me?network_id=0x4&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}&callback_type=post`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -447,7 +447,7 @@ describe('ConnectCore', () => {
       })
       return uport.requestAddress().then(address => {
         expect(address, 'uport.requestAddress address').to.equal(KOVAN_ADDRESS)
-        expect(uriHandler.calledWith(`me.uport:me?network_id=0x2a&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`), uriHandler.lastCall.args[0]).to.be.true
+        expect(uriHandler.calledWith(`me.uport:me?network_id=0x2a&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}&callback_type=post`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -482,7 +482,7 @@ describe('ConnectCore', () => {
       })
       return uport.attestCredentials(PAYLOAD).then((result) => {
         expect(result, 'uport.attestCredentials response').to.equal('ok')
-        expect(uriHandler.calledWith(`me.uport:add?attestations=${ATTESTATION}&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123`), uriHandler.lastCall.args[0]).to.be.true
+        expect(uriHandler.calledWith(`me.uport:add?attestations=${ATTESTATION}&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&callback_type=post`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -503,7 +503,7 @@ describe('ConnectCore', () => {
       })
       return uport.sendTransaction({to: CONTRACT, value: '0xff'}).then(txhash => {
         expect(txhash, 'uport.sendTransaction txhash').to.equal(FAKETX)
-        expect(uriHandler.calledWith(`me.uport:2opgxRd4H4WHiZwxGzGQr4HG942X12d39LJ?value=255&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`), uriHandler.lastCall.args[0]).to.be.true
+        expect(uriHandler.calledWith(`me.uport:2opgxRd4H4WHiZwxGzGQr4HG942X12d39LJ?value=255&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}&callback_type=post`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -530,7 +530,7 @@ describe('ConnectCore', () => {
         expect(txhash, 'uport.sendTransaction txhash').to.equal(FAKETX)
         // Note it intentionally leaves out data as function overrides it
         // gas is not included in uri
-        expect(uriHandler.calledWith(`me.uport:2opgxRd4H4WHiZwxGzGQr4HG942X12d39LJ?value=255&function=transfer(address%200x3b2631d8e15b145fd2bf99fc5f98346aecdc394c%2Cuint%2012312)&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=0xa19320ce2f72768054ac01248734c7d4f9929f6d`), uriHandler.lastCall.args[0]).to.be.true
+        expect(uriHandler.calledWith(`me.uport:2opgxRd4H4WHiZwxGzGQr4HG942X12d39LJ?value=255&function=transfer(address%200x3b2631d8e15b145fd2bf99fc5f98346aecdc394c%2Cuint%2012312)&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=0xa19320ce2f72768054ac01248734c7d4f9929f6d&callback_type=post`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -554,7 +554,7 @@ describe('ConnectCore', () => {
         gas: '0x4444'
       }).then(txhash => {
         expect(txhash, 'uport.sendTransaction txhash').to.equal('FAKETX')
-        expect(uriHandler.calledWith(`me.uport:2opgxRd4H4WHiZwxGzGQr4HG942X12d39LJ?value=255&bytecode=abcdef01&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`), uriHandler.lastCall.args[0]).to.be.true
+        expect(uriHandler.calledWith(`me.uport:2opgxRd4H4WHiZwxGzGQr4HG942X12d39LJ?value=255&bytecode=abcdef01&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}&callback_type=post`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -611,7 +611,7 @@ describe('ConnectCore', () => {
       const token = contract.at('0x819320ce2f72768054ac01248734c7d4f9929f6c')
       return token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312).then(txhash => {
         expect(txhash, 'token.transfer txhash').to.equal(FAKETX)
-        expect(uriHandler.calledWith(`me.uport:2opgxRd4H4WHiZwxGzGQr4HG942X12d39LJ?function=transfer(address%200x3b2631d8e15b145fd2bf99fc5f98346aecdc394c%2C%20uint256%2012312)&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`), uriHandler.lastCall.args[0]).to.be.true
+        expect(uriHandler.calledWith(`me.uport:2opgxRd4H4WHiZwxGzGQr4HG942X12d39LJ?function=transfer(address%200x3b2631d8e15b145fd2bf99fc5f98346aecdc394c%2C%20uint256%2012312)&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}&callback_type=post`), uriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })
@@ -630,7 +630,7 @@ describe('ConnectCore', () => {
       const token = uport.contract(miniTokenABI).at('0x819320ce2f72768054ac01248734c7d4f9929f6c')
       return token.transfer('0x3b2631d8e15b145fd2bf99fc5f98346aecdc394c', 12312, overideUriHandler).then(txhash => {
         expect(txhash, 'token.transfer txhash').to.equal(FAKETX)
-        expect(overideUriHandler.calledWith(`me.uport:2opgxRd4H4WHiZwxGzGQr4HG942X12d39LJ?function=transfer(address%200x3b2631d8e15b145fd2bf99fc5f98346aecdc394c%2C%20uint256%2012312)&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}`), overideUriHandler.lastCall.args[0]).to.be.true
+        expect(overideUriHandler.calledWith(`me.uport:2opgxRd4H4WHiZwxGzGQr4HG942X12d39LJ?function=transfer(address%200x3b2631d8e15b145fd2bf99fc5f98346aecdc394c%2C%20uint256%2012312)&label=UportTests&callback_url=https%3A%2F%2Fchasqui.uport.me%2Fapi%2Fv1%2Ftopic%2F123&client_id=${CLIENT_ID}&callback_type=post`), overideUriHandler.lastCall.args[0]).to.be.true
       }, error => {
         throw new Error('uport.request Promise rejected, expected it to resolve')
       })


### PR DESCRIPTION
This doesn't seem to be a sufficient default solution, since the urihandler could include any developer functionality and they may choose to transmit the uri in a number of ways, we can not differentiate when the uri will be shown in a QR or not. They may be creating a mobile link there. We can only know for sure when they use the default flow. We do provide the mobile handling even if sometimes using custom uri handler, so may often be sufficient there as well