### PR TITLE
feat/update account type values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/uport-connect
+    docker:
+      - image: circleci/node:8
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - dependencies-cache-{{ checksum "package.json" }}
+
+      - run:
+          name: install-dependencies
+          command: yarn
+
+      - run:
+          name: test
+          command: npm run karma-CI
+
+      - run:
+          name: code-coverage
+          command: bash <(curl -s https://codecov.io/bash)
+
+      - run:
+          name: dist
+          command: npm run build-dist && npm run build-dist-prod
+
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/uport-connect
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:8-browsers
     steps:
       - checkout
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -369,7 +369,7 @@ Instantiates a new uPort connectCore object.
 | opts.uriHandler | <code>function</code> |  | default function to consume generated URIs for requests, can be used to display QR codes or other custom UX |
 | opts.mobileUriHandler | <code>function</code> |  | default function to consume generated URIs for requests on mobile |
 | opts.closeUriHandler | <code>function</code> |  | default function called after a request receives a response, can be to close QR codes or other custom UX |
-| opts.accountType | <code>String</code> |  | Ethereum account type: "general", "segregated", "keypair", "devicekey" or "none" |
+| opts.accountType | <code>String</code> |  | Ethereum account type: "general", "segregated", "keypair", or "none" |
 
 **Example**  
 ```js

--- a/src/ConnectCore.js
+++ b/src/ConnectCore.js
@@ -140,7 +140,7 @@ class ConnectCore {
    */
   requestCredentials (request = {}, uriHandler) {
     const topic = this.topicFactory('access_token')
-    request.accountType = this.accountType || request.accountType || 'none'
+    request.accountType = request.accountType || this.accountType || 'none'
 
     return new Promise((resolve, reject) => {
       if (this.canSign) {

--- a/src/ConnectCore.js
+++ b/src/ConnectCore.js
@@ -81,7 +81,7 @@ class ConnectCore {
     this.mobileUriHandler = opts.mobileUriHandler
     this.closeUriHandler = opts.closeUriHandler
     this.clientId = opts.clientId
-    this.accountType = opts.accountType || 'none'
+    this.accountType = opts.accountType
     this.network = configNetwork(opts.network)
     if (this.accountType === 'segregated' && this.network === networks.mainnet) {
       throw new Error('Segregated accounts are not supported on Mainnet')
@@ -108,7 +108,8 @@ class ConnectCore {
    */
   getProvider () {
     const subProvider = new UportSubprovider({
-      requestAddress: this.requestAddress.bind(this),
+      requestAddress: () => this.requestCredentials({accountType: 'keypair'})
+        .then((profile) => profile.networkAddress || profile.address),
       sendTransaction: this.sendTransaction.bind(this),
       provider: this.provider || new HttpProvider(this.network.rpcUrl),
       networkId: this.network.id
@@ -139,7 +140,7 @@ class ConnectCore {
    */
   requestCredentials (request = {}, uriHandler) {
     const topic = this.topicFactory('access_token')
-    if (this.accountType) request.accountType = this.accountType
+    request.accountType = this.accountType || request.accountType || 'none'
 
     return new Promise((resolve, reject) => {
       if (this.canSign) {

--- a/src/ConnectCore.js
+++ b/src/ConnectCore.js
@@ -81,7 +81,7 @@ class ConnectCore {
     this.mobileUriHandler = opts.mobileUriHandler
     this.closeUriHandler = opts.closeUriHandler
     this.clientId = opts.clientId
-    this.accountType = opts.accountType
+    this.accountType = opts.accountType === 'none' ? undefined : opts.accountType
     this.network = configNetwork(opts.network)
     if (this.accountType === 'segregated' && this.network === networks.mainnet) {
       throw new Error('Segregated accounts are not supported on Mainnet')

--- a/src/ConnectCore.js
+++ b/src/ConnectCore.js
@@ -108,7 +108,7 @@ class ConnectCore {
    */
   getProvider () {
     const subProvider = new UportSubprovider({
-      requestAddress: () => this.requestCredentials({accountType: 'keypair'})
+      requestAddress: () => this.requestCredentials({accountType: this.accountType || 'keypair'})
         .then((profile) => profile.networkAddress || profile.address),
       sendTransaction: this.sendTransaction.bind(this),
       provider: this.provider || new HttpProvider(this.network.rpcUrl),

--- a/test/ConnectCore.js
+++ b/test/ConnectCore.js
@@ -65,6 +65,7 @@ describe('ConnectCore', () => {
       expect(uport.credentials).to.be.an.instanceof(Credentials)
       expect(uport.canSign).to.be.false
       expect(uport.getWeb3).to.equal(undefined)
+      expect(uport.accountType).to.equal('none')
     })
 
     it('does not have a closeUriHandler if not using built in openQr', () => {
@@ -100,6 +101,10 @@ describe('ConnectCore', () => {
     it('throws error if the network config object is not well formed ', () => {
       try { new ConnectCore('test app', {network: {id: '0x5'}}) } catch (e) { return }
       throw new Error('did not throw error')
+    })
+
+    it('throws error if segregated account is requested on mainnet', () => {
+      expect(() => new ConnectCore('test app', {network: 'mainnet', accountType: 'segregated'})).to.throw()
     })
   })
 

--- a/test/ConnectCore.js
+++ b/test/ConnectCore.js
@@ -65,7 +65,7 @@ describe('ConnectCore', () => {
       expect(uport.credentials).to.be.an.instanceof(Credentials)
       expect(uport.canSign).to.be.false
       expect(uport.getWeb3).to.equal(undefined)
-      expect(uport.accountType).to.equal('none')
+      expect(uport.accountType).to.equal(undefined)
     })
 
     it('does not have a closeUriHandler if not using built in openQr', () => {
@@ -295,7 +295,7 @@ describe('ConnectCore', () => {
                 return PROFILE
               },
               createRequest: (payload) => {
-                expect(payload).to.be.deep.equal({ callbackUrl: 'https://chasqui.uport.me/api/v1/topic/123', network_id: '0x4' })
+                expect(payload).to.be.deep.equal({ callbackUrl: 'https://chasqui.uport.me/api/v1/topic/123', network_id: '0x4', accountType: 'none' })
                 return REQUEST_TOKEN
               }
             })
@@ -327,7 +327,7 @@ describe('ConnectCore', () => {
               return PROFILE
             },
             createRequest: (payload) => {
-              expect(payload).to.be.deep.equal({ callbackUrl: 'https://chasqui.uport.me/api/v1/topic/123', network_id: '0x2a' })
+              expect(payload).to.be.deep.equal({ callbackUrl: 'https://chasqui.uport.me/api/v1/topic/123', network_id: '0x2a', accountType: 'none' })
               return REQUEST_TOKEN
             }
           })
@@ -359,6 +359,7 @@ describe('ConnectCore', () => {
             createRequest: (payload) => {
               expect(payload).to.be.deep.equal({
                 requested: ['phone'],
+                accountType: 'none',
                 network_id: '0x4',
                 notifications: true,
                 callbackUrl: 'https://chasqui.uport.me/api/v1/topic/123'
@@ -394,6 +395,7 @@ describe('ConnectCore', () => {
             createRequest: (payload) => {
               expect(payload).to.be.deep.equal({
                 notifications: true,
+                accountType: 'none',
                 network_id: '0x4',
                 callbackUrl: 'https://chasqui.uport.me/api/v1/topic/123'
               })
@@ -482,6 +484,34 @@ describe('ConnectCore', () => {
       const uport = new ConnectCore('test app', {network: netConfig})
       const provider = uport.getProvider()
       expect(uport.network.rpcUrl, 'uport.network.rpcUrl').to.equal(provider.provider.host)
+    })
+
+    it('requests a keypair account by default when calling getAddress', () => {
+      const uport = new ConnectCore('test app', {
+        topicFactory: () => mockTopic('Fake'),
+        uriHandler: sinon.spy(),
+        credentials: mockSigningCredentials({
+          receive: () => PROFILE,
+          createRequest: (payload) => { expect(payload.accountType).to.equal('keypair') }
+        })
+      })
+      const provider = uport.getProvider()
+      provider.getAddress((err) => expect(err).to.be.null)
+    })
+
+    it('requests the configured accountType if specified when calling getAddress', () => {
+      const accountType = 'general'
+      const uport = new ConnectCore('test app', {
+        accountType,
+        topicFactory: () => mockTopic('Fake'),
+        uriHandler: sinon.spy(),
+        credentials: mockSigningCredentials({
+          receive: () => PROFILE,
+          createRequest: (payload) => { expect(payload.accountType).to.equal(accountType) }
+        })
+      })
+      const provider = uport.getProvider()
+      provider.getAddress((err) => expect(err).to.be.null)
     })
   })
 


### PR DESCRIPTION
Updates to the handling of the accountType parameter in `ConnectCore`, from iis#46-49 (if I'm understanding them all correctly)

- Throw error if user requests a segregated account on mainnet
- Removed mention of 'deviceKey' account type from comment and DOCS.md
- Changes the default accountType sent with `requestCredentials` to  'none'
  - The default property value for connect.accountType is still `undefined`, but it is only ever used in requestCredentials, and the default is set then to simplify detecting an unset value.
- The getAddress method of uportSubprovider now will set `accountType` to 'keypair' if it's not already set.  This made the bound method in ConnectCore.js:111 a little uglier, explicitly calling `requestCredentials` rather than `requestAddress`, but this seemed better than changing the interface for `requestAddress` to accept `accountType` just for this specific case.
- Added tests for each of these changes, and updated other tests to expect `accountType: 'none'` when checking requests made by `requestCredentials`

resolves uport-project/iis#46
resolves uport-project/iis#47 
resolves uport-project/iis#48
resolves uport-project/iis#49