### PR TITLE
Feat/did major/state management

### DIFF
--- a/src/Connect.js
+++ b/src/Connect.js
@@ -438,18 +438,9 @@ class Connect {
    * and localStorage.  Rebuild this.credentials with a new app-instance identity
    */
   reset() {
-    this.setState({
-      did: null,
-      mnid: null,
-      address: null,
-      doc: null,
-      pushToken: null,
-      publicEncKey: null,
-      keypair: Credentials.createIdentity()
-    })
-
-    // Clear other instance variables and rebuild credentials
-    this.pushTransport = null
+    this.logout()
+    // Rebuild credentials
+    this.keypair = Credentials.createIdentity()
     this.credentials = new Credentials({...this.keypair, ...this.resolverConfigs})
   }
 

--- a/src/Connect.js
+++ b/src/Connect.js
@@ -395,7 +395,9 @@ class Connect {
     }
 
     // Write to localStorage
-    store.set('connectState', JSON.stringify(this._state))
+    if (this.storage) {
+      store.set('connectState', JSON.stringify(this._state))
+    } 
   }
 
   /**

--- a/src/Connect.js
+++ b/src/Connect.js
@@ -112,13 +112,7 @@ class Connect {
       requestAddress: () => {
         const requestID = 'addressReqProvider'
         this.requestDisclosure({accountType: this.accountType || 'keypair'}, requestID)
-        return this.onResponse(requestID).then(payload => {
-          // improve set/get state
-          this.address = payload.res.address
-          this.mnid = payload.res.mnid
-          this.did = payload.res.did
-          return this.address
-        })
+        return this.onResponse(requestID).then(payload => this.address)
       },
       sendTransaction: (txObj) => {
         delete txObj['from']
@@ -150,8 +144,10 @@ class Connect {
           return Promise.resolve(Object.assign({id}, payload))
         }
         return this.verifyResponse(jwt).then(res => {
-          this.setState({address: res.address, mnid: res.mnid, did: res.did})
-
+          // Set identifiers present in the response
+          if (res.address) this.address = res.address
+          if (res.mnid) this.mnid = mnid
+          if (res.did) this.did = res.did
           // Setup push transport if response contains pushtoken
           if (res.boxPub) this.publicEncKey = res.boxPub
           if (res.pushToken) this.pushToken = res.pushToken
@@ -475,6 +471,7 @@ class Connect {
    * @returns {Object}  addressAndMnid  -- an object with propreties address, and mnid containing both
    */
   mnidDecode(addressOrMnid) {
+    if (!addressOrMnid) return {adddress: undefined, mnid: undefined}
     const address = isMNID(addressOrMnid) ? decode(addressOrMnid).address : addressOrMnid
     const mnid = isMNID(addressOrMnid) ? addressOrMnid : encode({network: this.network.id, address: addressOrMnid})
     return {address, mnid}

--- a/src/Connect.js
+++ b/src/Connect.js
@@ -56,11 +56,12 @@ class Connect {
       throw new Error('Segregated accounts are not supported on mainnet')
     }
 
+    // Initialize private state
     this._state = NULL_STATE
 
     // Load any existing state if any
     if (this.storage) this.getState()
-    if (!this.keypair || !this.keypair.did) this.keypair = Credentials.createIdentity()
+    if (!this.keypair.did) this.keypair = Credentials.createIdentity()
     if (this.storage) this.setState()
 
     // Transports
@@ -74,25 +75,10 @@ class Connect {
       this.pubResponse(payload)
     })
 
-    // State
-    this.did = null
-    this.mnid = null
-    this.address = null
-    this.doc = null
-    this.pushToken = null
-    this.publicEncKey = null
-
-    // Load any existing state if any
-    if (this.storage) this.getState()
-    if (!this.keypair) this.keypair = Credentials.createIdentity()
-    if (this.storage) this.setState()
-
     // Credential (uport-js) config for verification
     this.registry = opts.registry || UportLite({ networks: network.config.networkToNetworkSet(this.network) })
     this.resolverConfigs = {registry: this.registry, ethrConfig: opts.ethrConfig, muportConfig: opts.muportConfig }
-
-    // TODO can resolver configs not be passed through
-    this.credentials = new Credentials(Object.assign(this.keypair, this.resolverConfigs))
+    this.credentials = new Credentials(Object.assign(this.keypair, this.resolverConfigs))     // TODO can resolver configs not be passed through
   }
 
  /**
@@ -148,9 +134,7 @@ class Connect {
         return this.verifyResponse(jwt).then(res => {
           // Set identifiers present in the response
           this.did = res.did
-          if (res.address) this.address = res.address
-          if (res.mnid) this.mnid = mnid
-          // Setup push transport if response contains pushtoken
+          if (res.mnid) this.mnid = res.mnid
           if (res.boxPub) this.publicEncKey = res.boxPub
           if (res.pushToken) this.pushToken = res.pushToken
           return {id, res, data: payload.data}
@@ -386,6 +370,14 @@ class Connect {
       default:
         throw new Error(`Cannot update state with ${update}`)
     }
+    // Normalize address to mnid
+    const { mnid } = this._state
+    if (isMNID(mnid)) {
+      this._state.address = decode(mnid).address
+    } else if (mnid) {
+      // Don't allow setting an invalid mnid
+      throw new Error(`Invalid MNID: ${this._state.mnid}`)
+    }
 
     if (this.publicEncKey && this.pushToken) {
       this.pushTransport = pushTransport(this.pushToken, this.publicEncKey)
@@ -452,24 +444,19 @@ class Connect {
    */
   set did (did)                   { this.setState({did}) }
   set doc (doc)                   { this.setState({doc}) }
-  set mnid (mnid)                 { this.setState(this.mnidDecode(mnid)) }
-  set address (address)           { this.setState(this.mnidDecode(address)) }
+  set mnid (mnid)                 { this.setState({mnid}) }
   set keypair (keypair)           { this.setState({keypair}) }
   set pushToken (pushToken)       { this.setState({pushToken}) }
   set publicEncKey (publicEncKey) { this.setState({publicEncKey}) }
 
-  /**
-   * Utility method for disambiguating an address or mnid;
-   * Receives either and return an object containing both, encoded according to this.network.id
-   *
-   * @param   {String}  addressOrMnid   -- A string containing an address or an mnid
-   * @returns {Object}  addressAndMnid  -- an object with properties address, and mnid containing both
-   */
-  mnidDecode(addressOrMnid) {
-    if (!addressOrMnid) return {adddress: undefined, mnid: undefined}
-    const address = isMNID(addressOrMnid) ? decode(addressOrMnid).address : addressOrMnid
-    const mnid = isMNID(addressOrMnid) ? addressOrMnid : encode({network: this.network.id, address: addressOrMnid})
-    return {address, mnid}
+  // Address field alone is deprectated.  Allow setting an mnid, but not an unqualified address
+  set address (address) {
+    if (isMNID(address)) {
+      this.setState({mnid: address})
+    } else {
+      if (address === this.address) return
+      throw new Error('Setting an Ethereum address without a network id is not supported.  Use an MNID instead.')
+    }
   }
 
   /**

--- a/test/Connect.js
+++ b/test/Connect.js
@@ -596,7 +596,6 @@ describe('transports', () => {
       expect(uport.address).to.equal('0x122bd1a75ae8c741f7e2ab0a28bd30b8dbb1a67e')
     })
 
-
     it('Saves to localStorage on assignment to state properties', () => {
       const uport = new Connect('testApp')
 
@@ -649,23 +648,53 @@ describe('transports', () => {
       expect(uport.publicEncKey).to.equal(uportTest.publicEncKey)
     })
 
-    // it('gets serialized state from local storage and calls deserialize with it', () => {
-    //   const uport = new Connect('testapp')
-    //   const deserialize = sinon.spy()
-    //   uport.deserialize = deserialize
-    //   // Set after connect instantiated
-    //   window.localStorage.setItem('connectState', 'uportTestStateString')
-    //   uport.getState()
-    //   expect(deserialize).to.be.calledWith('uportTestStateString')
-    // })
+    const testState = {
+      address: '0x00521965e7bd230323c423d96c657db5b79d099f',
+      mnid: '2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG',
+      doc: {name: 'Ran'},
+      did: 'did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG',
+      publicEncKey: 'test public key',
+      pushToken: 'test push token',
+      keypair: {did: 'did:ethr:0x413daa771a2fc9c5ae5a66abd144881ef2498c54' , keypair: '1338f32fefb4db9b2deeb15d8b1b428a6346153cc43f51ace865986871dd069d'}
+    }
 
-    // it('writes serialized state to local storage at connectState ', () => {
-    //   const uport = new Connect('testapp')
-    //   const serialize = sinon.stub().callsFake(() => 'uportTestStateString')
-    //   uport.serialize = serialize
-    //   uport.setState()
-    //   expect(serialize).to.be.called
-    //   expect(window.localStorage.getItem('connectState')).to.equal('"uportTestStateString"')
-    // })
+    const logoutState = {
+      address: null,
+      mnid: null,
+      doc: null,
+      did: null, 
+      publicEncKey: null,
+      pushToken: null, 
+      keypair: {did: 'did:ethr:0x413daa771a2fc9c5ae5a66abd144881ef2498c54' , keypair: '1338f32fefb4db9b2deeb15d8b1b428a6346153cc43f51ace865986871dd069d'}
+    }
+
+    it('clears all state except for keypair on logout', () => {
+      const uport = new Connect('testApp')
+
+      uport.setState(testState)
+
+      expect(JSON.parse(uport.getState())).to.deep.equal(testState)
+      expect(uport.pushTransport).to.be.a('function')
+
+      uport.logout()
+      expect(JSON.parse(uport.getState())).to.deep.equal(logoutState)
+      expect(uport.pushTransport).to.be.null
+    })
+
+    it('clears all state including keypair on reset ', () => {
+      const uport = new Connect('testApp')
+
+      uport.setState(testState)
+      expect(JSON.parse(uport.getState())).to.deep.equal(testState)
+      expect(uport.pushTransport).to.be.a('function')
+      const oldCredentials = uport.credentials
+
+      uport.reset()
+
+      expect(uport.did).to.be.null
+      expect(uport.pushTransport).to.be.null
+      expect(uport.credentials).not.to.equal(oldCredentials)
+      expect(uport.credentials).not.to.deep.equal(oldCredentials)
+    })
   })
 })

--- a/test/Connect.js
+++ b/test/Connect.js
@@ -203,25 +203,25 @@ describe('Connect', () => {
       expect(uport.network.rpcUrl, 'uport.network.rpcUrl').to.equal(provider.provider.host)
     })
 
-    it('returns provider which calls connect.requestAddress on getCoinbase', (done) => {
-      const uport = new Connect('test app')
-      const mnid = '2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG'
-      const addressTest = '0x122bd1a75ae8c741f7e2ab0a28bd30b8dbb1a67e'
-      const verifyResponse = sinon.stub().resolves({'name': 'uPort Demo', '@type': 'App', 'description': 'Demo App', 'url': 'demo.uport.me', 'address': '0x122bd1a75ae8c741f7e2ab0a28bd30b8dbb1a67e'})
-      uport.verifyResponse = verifyResponse
-      uport.requestDisclosure = sinon.stub()
-      const web3 = new Web3(uport.getProvider())
-      web3.eth.getCoinbase((error, address) => {
-        if (error) console.log(error)
-        console.log('HERE', address, addressTest)
-        expect(address).to.equal(addressTest)
-        done()
-      })
-      // Fake response
-      const resId = 'addressReqProvider'
-      const res = { id: resId, res: resJWT, data: '' }
-      uport.pubResponse(res)
-    })
+    // it('returns provider which calls connect.requestAddress on getCoinbase', (done) => {
+    //   const uport = new Connect('test app')
+    //   const mnid = '2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG'
+    //   const addressTest = '0x122bd1a75ae8c741f7e2ab0a28bd30b8dbb1a67e'
+    //   const verifyResponse = sinon.stub().resolves({'name': 'uPort Demo', '@type': 'App', 'description': 'Demo App', 'url': 'demo.uport.me', 'address': '0x122bd1a75ae8c741f7e2ab0a28bd30b8dbb1a67e'})
+    //   uport.verifyResponse = verifyResponse
+    //   uport.requestDisclosure = sinon.stub()
+    //   const web3 = new Web3(uport.getProvider())
+    //   web3.eth.getCoinbase((error, address) => {
+    //     if (error) console.log(error)
+    //     console.log('HERE', address, addressTest)
+    //     expect(address).to.equal(addressTest)
+    //     done()
+    //   })
+    //   // Fake response
+    //   const resId = 'addressReqProvider'
+    //   const res = { id: resId, res: resJWT, data: '' }
+    //   uport.pubResponse(res)
+    // })
 
     it('returns provider which calls connect.txRequest on transaction calls', () => {
       const uport = new Connect('testApp')

--- a/test/Connect.js
+++ b/test/Connect.js
@@ -203,25 +203,26 @@ describe('Connect', () => {
       expect(uport.network.rpcUrl, 'uport.network.rpcUrl').to.equal(provider.provider.host)
     })
 
-    // it('returns provider which calls connect.requestAddress on getCoinbase', (done) => {
-    //   const uport = new Connect('test app')
-    //   const mnid = '2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG'
-    //   const addressTest = '0x122bd1a75ae8c741f7e2ab0a28bd30b8dbb1a67e'
-    //   const verifyResponse = sinon.stub().resolves({'name': 'uPort Demo', '@type': 'App', 'description': 'Demo App', 'url': 'demo.uport.me', 'address': '0x122bd1a75ae8c741f7e2ab0a28bd30b8dbb1a67e'})
-    //   uport.verifyResponse = verifyResponse
-    //   uport.requestDisclosure = sinon.stub()
-    //   const web3 = new Web3(uport.getProvider())
-    //   web3.eth.getCoinbase((error, address) => {
-    //     if (error) console.log(error)
-    //     console.log('HERE', address, addressTest)
-    //     expect(address).to.equal(addressTest)
-    //     done()
-    //   })
-    //   // Fake response
-    //   const resId = 'addressReqProvider'
-    //   const res = { id: resId, res: resJWT, data: '' }
-    //   uport.pubResponse(res)
-    // })
+    it('returns provider which calls connect.requestDisclosure on getCoinbase', (done) => {
+      const uport = new Connect('test app')
+      const mnid = '2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG'
+      const addressTest = '0x122bd1a75ae8c741f7e2ab0a28bd30b8dbb1a67e'
+      const verifyResponse = sinon.stub().resolves({'name': 'uPort Demo', '@type': 'App', 'description': 'Demo App', 'url': 'demo.uport.me', 'address': '0x122bd1a75ae8c741f7e2ab0a28bd30b8dbb1a67e', did: `did:uport:${mnid}`})
+      uport.verifyResponse = verifyResponse
+
+      // uport.requestDisclosure = sinon.stub()
+      const web3 = new Web3(uport.getProvider())
+      web3.eth.getCoinbase((error, address) => {
+        if (error) console.log(error.error)
+        expect(address).to.equal(addressTest)
+        done()
+      })
+
+      // Fake response
+      const resId = 'addressReqProvider'
+      const res = { id: resId, res: resJWT, data: '' }
+      uport.pubResponse(res)
+    })
 
     it('returns provider which calls connect.txRequest on transaction calls', () => {
       const uport = new Connect('testApp')

--- a/test/Connect.js
+++ b/test/Connect.js
@@ -588,12 +588,12 @@ describe('transports', () => {
     it('Ensures agreement between mnid and address', () => {
       const uport = new Connect('testApp')
 
-      uport.did = '0x122bd1a75ae8c741f7e2ab0a28bd30b8dbb1a67e'
+      uport.address = '0x122bd1a75ae8c741f7e2ab0a28bd30b8dbb1a67e'
       expect(uport.mnid).to.equal('2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG')
 
       const uport2 = new Connect('testApp')
       uport.mnid = '2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG'
-      expect(uport.did).to.equal('0x122bd1a75ae8c741f7e2ab0a28bd30b8dbb1a67e')
+      expect(uport.address).to.equal('0x122bd1a75ae8c741f7e2ab0a28bd30b8dbb1a67e')
     })
 
 


### PR DESCRIPTION
Improved the handling of Connect state.  The same properties are still available, but they now call setters and getters which wrap a react-style `setState` function which operates on `Connect._state`.  `Connect.setState` can accept an object, function, or (serialized json) string.  If `Connect.storage` is true, it will also persist state to localStorage with every update.  The functional option operates as a reducer, accepting a function of the current state which returns an updated state object.  State properties that are not mentioned by a call to `setState` are left unchanged.

`Connect.keypair` and `Connect.doc` also return a clone of the internal object, so it can be freely mutated without corrupting the Connect state.

Additionally, added the method `mnidDecode` (maybe could use a better name?) which accepts an address or mnid, and returns an object containing both the address and the mnid appropriate for the current network.  Attempting to set either `Connect.mnid` or `Connect.address` will call this function and set both according to the output.  This keeps the two from going out of sync by writing to one and forgetting to update the other.

resolves uport-project/iis#45