### PR TITLE
Support for eip 712 request in Connect and UportSubprovider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2579,8 +2579,7 @@
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "dev": true
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
       "version": "2.1.0",
@@ -7602,8 +7601,7 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-property": {
       "version": "1.0.2",
@@ -10872,8 +10870,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
       "version": "0.1.5",
@@ -11368,7 +11365,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-      "dev": true,
       "requires": {
         "find-up": "^2.1.0"
       }
@@ -14355,8 +14351,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "0.6.5",
@@ -14427,7 +14422,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
@@ -14520,8 +14514,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tsscmp": {
       "version": "1.0.5",
@@ -14895,6 +14888,11 @@
         "webpack-cli": "^3.1.0"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -14923,9 +14921,22 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "chardet": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "requires": {
+            "restore-cursor": "^2.0.0"
           }
         },
         "cliui": {
@@ -14963,13 +14974,31 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
           "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
           "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "6.0.5",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "external-editor": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+          "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+          "requires": {
+            "chardet": "^0.7.0",
+            "iconv-lite": "^0.4.24",
+            "tmp": "^0.0.33"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "find-up": {
@@ -14985,13 +15014,40 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
         "import-local": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
           "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
           "requires": {
-            "pkg-dir": "^3.0.0",
             "resolve-cwd": "^2.0.0"
+          }
+        },
+        "inquirer": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+          "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.10",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.1.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           }
         },
         "invert-kv": {
@@ -15026,9 +15082,22 @@
           "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
           "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
           "requires": {
-            "map-age-cleaner": "^0.1.1",
-            "mimic-fn": "^1.0.0",
-            "p-is-promise": "^1.1.0"
+            "map-age-cleaner": "0.1.2",
+            "mimic-fn": "1.2.0",
+            "p-is-promise": "1.1.0"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "requires": {
+            "mimic-fn": "^1.0.0"
           }
         },
         "os-locale": {
@@ -15062,12 +15131,29 @@
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
           "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
         },
-        "pkg-dir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "requires": {
-            "find-up": "^3.0.0"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
+        },
+        "rxjs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
+          "integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
+          "requires": {
+            "tslib": "^1.9.0"
           }
         },
         "string-width": {
@@ -15106,20 +15192,32 @@
           "integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw=="
         },
         "webpack-cli": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.1.2.tgz",
-          "integrity": "sha512-Cnqo7CeqeSvC6PTdts+dywNi5CRlIPbLx1AoUPK2T6vC1YAugMG3IOoO9DmEscd+Dghw7uRlnzV1KwOe5IrtgQ==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.1.0.tgz",
+          "integrity": "sha512-p5NeKDtYwjZozUWq6kGNs9w+Gtw/CPvyuXjXn2HMdz8Tie+krjEg8oAtonvIyITZdvpF7XG9xDHwscLr2c+ugQ==",
           "requires": {
             "chalk": "^2.4.1",
             "cross-spawn": "^6.0.5",
-            "enhanced-resolve": "^4.1.0",
-            "global-modules-path": "^2.3.0",
-            "import-local": "^2.0.0",
+            "enhanced-resolve": "^4.0.0",
+            "global-modules-path": "^2.1.0",
+            "import-local": "^1.0.0",
+            "inquirer": "^6.0.0",
             "interpret": "^1.1.0",
             "loader-utils": "^1.1.0",
-            "supports-color": "^5.5.0",
-            "v8-compile-cache": "^2.0.2",
-            "yargs": "^12.0.2"
+            "supports-color": "^5.4.0",
+            "v8-compile-cache": "^2.0.0",
+            "yargs": "^12.0.1"
+          },
+          "dependencies": {
+            "import-local": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+              "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+              "requires": {
+                "pkg-dir": "^2.0.0",
+                "resolve-cwd": "^2.0.0"
+              }
+            }
           }
         },
         "xregexp": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "pubsub-js": "^1.6.0",
     "qs": "^6.2.1",
     "store": "^2.0.12",
-    "uport-credentials": "1.1.0-alpha-2",
+    "uport-credentials": "^1.1.0-alpha-2",
     "uport-did-resolver": "0.0.3",
     "uport-lite": "^1.0.2",
     "uport-transports": "0.0.67"

--- a/src/Connect.js
+++ b/src/Connect.js
@@ -116,7 +116,7 @@ class Connect {
       },
       signTypedData: (typedData) => {
         const requestID = 'typedDataSigReqProvider'
-        this.requestTypedDataSignature(typeData, requestID)
+        this.requestTypedDataSignature(typedData, requestID)
         return this.onResponse(requestID).then(res => res.payload)
       },
       provider, network: this.network

--- a/src/Connect.js
+++ b/src/Connect.js
@@ -114,6 +114,11 @@ class Connect {
         this.sendTransaction(txObj, requestID)
         return this.onResponse(requestID).then(res => res.payload)
       },
+      signTypedData: (typedData) => {
+        const requestID = 'typedDataSigReqProvider'
+        this.requestTypedDataSignature(typeData, requestID)
+        return this.onResponse(requestID).then(res => res.payload)
+      },
       provider, network: this.network
     })
     if (this.address) subProvider.setAccount(this.address)
@@ -287,7 +292,7 @@ class Connect {
   }
 
   /**
-   *  Creates a request for a user to [sign a verification](https://github.com/uport-project/specs/blob/develop/messages/verificationreq.md) and sends the request to the uPort user.
+   *  Creates and sends a request for a user to [sign a verification](https://github.com/uport-project/specs/blob/develop/messages/verificationreq.md) and sends the request to the uPort user.
    *
    *  @example
    *  const unsignedClaim = {
@@ -311,6 +316,18 @@ class Connect {
   async requestVerificationSignature (unsignedClaim, sub, id = 'verSigReq', sendOpts) {
     await this.signAndUploadProfile()
     this.credentials.createVerificationSignatureRequest(unsignedClaim, {sub, aud: this.did, callbackUrl: this.genCallback(id), vc: this.vc})
+      .then(jwt => this.send(jwt, id, sendOpts))
+  }
+
+  /**
+   * Creates and sends a request to a user to sign a piece of ERC712 Typed Data
+   * 
+   * @param     {Object}    typedData             an object containing unsigned typed, structured data that follows the ERC712 specification  
+   * @param     {String}    [id='signVerReq']     string to identify request, later used to get response
+   * @param     {Object}    [sendOpts]            reference send function options
+   */
+  requestTypedDataSignature (typedData, id = 'typedDataSigReq', sendOpts) {
+    this.credentials.createTypedDataSignatureRequest(typedData, {aud: this.did, callbackUrl: this.genCallback(id)})
       .then(jwt => this.send(jwt, id, sendOpts))
   }
 

--- a/src/UportSubprovider.js
+++ b/src/UportSubprovider.js
@@ -123,7 +123,7 @@ class UportSubprovider {
       case 'eth_signTypedData':
         let typedData = payload.params[0]
         return self.signTypedData(typedData, (err, result) => {
-          response(err, result)
+          respond(err, result)
         })
       default:
         return self.provider.sendAsync(payload, callback)

--- a/src/UportSubprovider.js
+++ b/src/UportSubprovider.js
@@ -17,7 +17,7 @@ class UportSubprovider {
    * @param       {Object}            args.provider          a web3 sytle provider
    * @return      {UportSubprovider}                         self
    */
-  constructor ({requestAddress, sendTransaction, provider, network}) {
+  constructor ({requestAddress, sendTransaction, signTypedData, provider, network}) {
     const self = this
 
     if (!provider) {
@@ -41,6 +41,13 @@ class UportSubprovider {
     this.sendTransaction = (txobj, cb) => {
       sendTransaction(txobj).then(
         address => cb(null, address),
+        error => cb(error)
+      )
+    }
+
+    this.signTypedData = (typedData, cb) => {
+      signTypedData(typedData).then(
+        payload => cb(null, payload),
         error => cb(error)
       )
     }
@@ -111,6 +118,12 @@ class UportSubprovider {
         let txParams = payload.params[0]
         return self.sendTransaction(txParams, (err, tx) => {
           respond(err, tx)
+        })
+      case 'eth_signTypedData_v3':
+      case 'eth_signTypedData':
+        let typedData = payload.params[0]
+        return self.signTypedData(typedData, (err, result) => {
+          response(err, result)
         })
       default:
         return self.provider.sendAsync(payload, callback)

--- a/src/UportSubprovider.js
+++ b/src/UportSubprovider.js
@@ -116,15 +116,11 @@ class UportSubprovider {
         })
       case 'eth_sendTransaction':
         let txParams = payload.params[0]
-        return self.sendTransaction(txParams, (err, tx) => {
-          respond(err, tx)
-        })
+        return self.sendTransaction(txParams, respond)
       case 'eth_signTypedData_v3':
       case 'eth_signTypedData':
         let typedData = payload.params[0]
-        return self.signTypedData(typedData, (err, result) => {
-          respond(err, result)
-        })
+        return self.signTypedData(typedData, respond)
       default:
         return self.provider.sendAsync(payload, callback)
     }

--- a/test/Connect.js
+++ b/test/Connect.js
@@ -596,8 +596,8 @@ describe('Connect', () => {
 
       const testId = 'test_signTypedData'
       const opts = {data: 'woop', type: 'woop', cancel: 'woop'}
-
-      uport.send = (jwt, sendId, sendOpts) => {
+    
+      uport.send = (jwt, id, sendOpts) => {
         verifyJWT(jwt, {audience: uport.keypair.did}).then(({payload, issuer}) => {
           expect(issuer).to.equal(uport.keypair.did)
           expect(payload.typedData).to.deep.equal(typedData)

--- a/test/UportSubprovider.js
+++ b/test/UportSubprovider.js
@@ -83,4 +83,15 @@ describe('UportSubprovider', () => {
   		done()
   	})
   })
+	
+  it('Calls the passed signTypedData function for `eth_signTypedData` request', (done) => {
+	const response = 'res'
+	const signTypedData = sinon.stub().resolves(response)
+	const uSub = new UportSubprovider({signTypedData, network})
+	uSub.sendAsync({method: 'eth_signTypedData', params: [{data: 'fake'}]}, (err, {result}) => {
+		expect(err).to.be.null
+		expect(result).to.equal(response)
+		done()
+  	})
+  })
 })


### PR DESCRIPTION

Add support for sending a signedTypedData request in uport-connect, as well as support for the `eth_signTypedData` and `eth_signTypedData_v3` requests in the `UportSubprovider`

Tests for these pass, with the exception of the one that depends on uport-project/uport-js#102 and its changes to the `Credentials` object.
