### PR TITLE
Fixing profile claim

### DIFF
--- a/src/Connect.js
+++ b/src/Connect.js
@@ -531,7 +531,7 @@ class Connect {
     }
     
     // Upload to ipfs
-    return this.credentials.createVerification({sub: this.did, claim: {profile}})
+    return this.credentials.createVerification({sub: this.did, claim: profile})
       .then(jwt => ipfsAdd(jwt))
       .then(hash => {
         console.log('uploaded, ', this.vc)

--- a/test/Connect.js
+++ b/test/Connect.js
@@ -258,7 +258,7 @@ describe('Connect', () => {
         ipfs.cat(uport.vc[0].replace(/^\/ipfs\//, ''), (err, res) => {
           if (err) reject(err)
           const { payload } = decodeJWT(res)
-          const { profile } = payload.claim
+          const profile = payload.claim
           expect(profile.name).to.equal(jwt.name)
           expect(profile.description).to.equal(jwt.description)
           expect(profile.url).to.equal(jwt.url)


### PR DESCRIPTION
@rmw2 the reason why app branding does not work, is because right now the claim is in this format 

```
{
  iss: '...',
  sub: '...',
  claim: {
    profile: {
      name: 'Demo app',
      url: 'demo...'
    }
  }
}
```

but should be like this:

```
{
  iss: '...',
  sub: '...',
  claim: {
    name: 'Demo app',
    url: 'demo...'
  }
}
```