### PR TITLE
Fix dependency in web3 example

### DIFF
--- a/examples/web3v1/package.json
+++ b/examples/web3v1/package.json
@@ -7,7 +7,7 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-scripts": "1.1.4",
-    "uport-connect": "file:../../lib",
+    "uport-connect": "file:../../",
     "web3": "^1.0.0-beta.35"
   },
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-connect",
-  "version": "1.0.0-alpha-5",
+  "version": "1.0.0-alpha-6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-connect",
-  "version": "1.0.0-alpha-5",
+  "version": "1.0.0-alpha-6",
   "description": "Library for integrating uPort into your app frontend",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
The dependency on `uport-connect` previously referred to `file:../../lib` which has no package.json.  Should be `file:../../`