### PR TITLE
Feat/update transports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14878,9 +14878,9 @@
       "integrity": "sha1-LzEM4NFU8HRQRT1Vnjzz2jEUeUw="
     },
     "uport-transports": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/uport-transports/-/uport-transports-0.1.0.tgz",
-      "integrity": "sha512-sniB4Y5M92Nn3Y4lbdcm5LibEqlzZlgQ5lpqFj7WNdJQXVNo1ptkbhGdDDQ8R9NYjw1xHG716vYud2VWIl7Yng==",
+      "version": "0.2.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/uport-transports/-/uport-transports-0.2.0-alpha.2.tgz",
+      "integrity": "sha512-n3nC9+lxi1Y7fWEcIPAgJ2Nw3ZtX36aL1q5Gr8DsIVTFGffgTB8MwQKxqGEqIIhBxRwSGeQU4UsUeVw6glWK9w==",
       "requires": {
         "async": "^2.6.0",
         "base64url": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14878,9 +14878,9 @@
       "integrity": "sha1-LzEM4NFU8HRQRT1Vnjzz2jEUeUw="
     },
     "uport-transports": {
-      "version": "0.2.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/uport-transports/-/uport-transports-0.2.0-alpha.2.tgz",
-      "integrity": "sha512-n3nC9+lxi1Y7fWEcIPAgJ2Nw3ZtX36aL1q5Gr8DsIVTFGffgTB8MwQKxqGEqIIhBxRwSGeQU4UsUeVw6glWK9w==",
+      "version": "0.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/uport-transports/-/uport-transports-0.2.0-alpha.4.tgz",
+      "integrity": "sha512-tjh7yXroX7sMAndTkv9hjHUAXHTtGAgL4/4cbYx4M6UG8CM0HYDdtV3Kb7xDZ+Dww9GCFS5PhjEP48TG++g4Xg==",
       "requires": {
         "async": "^2.6.0",
         "base64url": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-connect",
-  "version": "1.1.0-alpha.8",
+  "version": "1.1.0-alpha.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-connect",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-connect",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.8",
   "description": "Library for integrating uPort into your app frontend",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-connect",
-  "version": "1.1.0-alpha.8",
+  "version": "1.1.0-alpha.9",
   "description": "Library for integrating uPort into your app frontend",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "uport-credentials": "^1.1.0-alpha-2",
     "uport-did-resolver": "0.0.3",
     "uport-lite": "^1.0.2",
-    "uport-transports": "^0.2.0-alpha.2"
+    "uport-transports": "^0.2.0-alpha.4"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "uport-credentials": "^1.1.0-alpha-2",
     "uport-did-resolver": "0.0.3",
     "uport-lite": "^1.0.2",
-    "uport-transports": "^0.1.0"
+    "uport-transports": "^0.2.0-alpha.2"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
Bump to `uport-transports@0.2.0-alpha.4`

This includes the fix for parsing chasqui responses so we can test new features in the demo app.