### PR TITLE
feat: add support for personal sign in Connect and Subprovider

### DIFF
--- a/src/Connect.js
+++ b/src/Connect.js
@@ -119,6 +119,11 @@ class Connect {
         this.requestTypedDataSignature(typedData, requestID)
         return this.onResponse(requestID).then(res => res.payload)
       },
+      personalSign: (data) => {
+        const requestID = 'personalSignReqProvider'
+        this.requestPersonalSign(data, requestID)
+        return this.onResponse(requestID).then(res => res.payload)
+      },
       provider, network: this.network
     })
     if (this.address) subProvider.setAccount(this.address)
@@ -322,13 +327,27 @@ class Connect {
   /**
    * Creates and sends a request to a user to sign a piece of ERC712 Typed Data
    * 
-   * @param     {Object}    typedData             an object containing unsigned typed, structured data that follows the ERC712 specification  
-   * @param     {String}    [id='signVerReq']     string to identify request, later used to get response
-   * @param     {Object}    [sendOpts]            reference send function options
+   * @param     {Object}    typedData               an object containing unsigned typed, structured data that follows the ERC712 specification  
+   * @param     {String}    [id='typedDataSigReq']  string to identify request, later used to get response
+   * @param     {Object}    [sendOpts]              reference send function options
    */
   requestTypedDataSignature (typedData, id = 'typedDataSigReq', sendOpts) {
     this.credentials.createTypedDataSignatureRequest(typedData, {riss: this.did, callback: this.genCallback(id)})
       .then(jwt => this.send(jwt, id, sendOpts))
+  }
+
+  /**
+   * Creates and sends a request to a user to sign an arbitrary data string
+   * 
+   * @param {String} data                   a string representing a piece of arbitrary data
+   * @param {String} [id='personalSignReq'] 
+   * @param {Object} [sendOpts]
+   */
+  requestPersonalSign(data, id='personalSignReq', sendOpts) {
+    if (data instanceof Buffer) {
+      data = data.toString('hex')
+    }
+    this.credentials.createPersonalSignRequest(data, {riss: this.did, callback: this.genCallback(id)}).then(jwt => this.send(jwt, id, sendOpts))
   }
 
   /**

--- a/src/UportSubprovider.js
+++ b/src/UportSubprovider.js
@@ -17,7 +17,7 @@ class UportSubprovider {
    * @param       {Object}            args.provider          a web3 sytle provider
    * @return      {UportSubprovider}                         self
    */
-  constructor ({requestAddress, sendTransaction, signTypedData, provider, network}) {
+  constructor ({requestAddress, sendTransaction, signTypedData, personalSign, provider, network}) {
     const self = this
 
     if (!provider) {
@@ -47,6 +47,13 @@ class UportSubprovider {
 
     this.signTypedData = (typedData, cb) => {
       signTypedData(typedData).then(
+        payload => cb(null, payload),
+        error => cb(error)
+      )
+    }
+
+    this.personalSign = (data, cb) => {
+      personalSign(data).then(
         payload => cb(null, payload),
         error => cb(error)
       )
@@ -121,6 +128,9 @@ class UportSubprovider {
       case 'eth_signTypedData':
         let typedData = payload.params[0]
         return self.signTypedData(typedData, respond)
+      case 'personal_sign':
+        let data = payload.params[0]
+        return self.personalSign(data, respond)
       default:
         return self.provider.sendAsync(payload, callback)
     }

--- a/test/Connect.js
+++ b/test/Connect.js
@@ -636,6 +636,78 @@ describe('Connect', () => {
     })
   })
 
+  describe('requestPersonalSign', () => {
+    const vc = ['fake']
+
+    it('calls credentials.createPersonalSignRequest with the correct args', (done) => {
+      const uport = new Connect('test app', {vc})
+      const opts = {test: 'test'}
+      const id = 'testid'
+      const data = 'deadbeef'
+      uport.credentials.createPersonalSignRequest = (testData, {riss, callback}) => {
+        expect(riss).to.equal(uport.did)
+        expect(callback).to.match(/\/topic\//)
+        expect(testData).to.equal(data)
+        return Promise.resolve('jwt')
+      }
+
+      uport.send = (jwt, testId, sendOpts) => {
+        expect(jwt).to.equal('jwt')
+        expect(sendOpts).to.equal(opts)
+        expect(testId).to.equal(id)
+        done()
+      }
+
+      uport.requestPersonalSign(data, id, opts)
+    })
+
+    it('formats Buffer as hex string', (done) => {
+      const uport = new Connect('test app', {vc})
+      const opts = {test: 'test'}
+      const id = 'testid'
+      const data = Buffer.from([0xde, 0xad, 0xbe, 0xef])
+      uport.did = 'test'
+      
+      uport.credentials.createPersonalSignRequest = (testData, {riss, callback}) => {
+        expect(riss).to.equal(uport.did)
+        expect(callback).to.match(/\/topic\//)
+        expect(testData).to.equal('deadbeef')
+        return Promise.resolve('jwt')
+      }
+
+      uport.send = (jwt, testId, sendOpts) => {
+        expect(jwt).to.equal('jwt')
+        expect(sendOpts).to.equal(opts)
+        expect(testId).to.equal(id)
+        done()
+      }
+
+      uport.requestPersonalSign(data, id, opts)
+    })
+
+    it('is called with the correct arguments from UportSubprovider', () => {
+      const uport = new Connect('test app', {vc})
+      const subprovider = uport.getProvider()
+
+      // Test that the request/response pair is the same
+      let reqId
+      uport.requestPersonalSign = (_, id) => reqId = id
+      uport.onResponse = (id) => {
+        expect(id).to.equal(reqId)
+        return Promise.resolve({payload: 'result'})
+      }
+
+      const payload = {method: 'personal_sign', id: 'test', params: []}
+      subprovider.sendAsync(payload, (err, {id, jsonrpc, result}) => {
+        expect(err).to.be.null
+        expect(id).to.equal(payload.id)
+        expect(jsonrpc).to.equal('2.0')
+        expect(result).to.equal('result')
+        done()
+      })
+    })
+  })
+
   /*********************************************************************/
 
   describe('contract', () => {


### PR DESCRIPTION
This adds a new method to connect, `requestPersonalSign`, as well as adds support for the `personal_sign` RPC call in the UportSubprovider.  Also adds tests for both.

This method depends on the `createPersonalSignRequest` method in uport-project/uport-credentials#130.

