### PR TITLE
chore: bump transports to include uri fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14800,9 +14800,9 @@
       "integrity": "sha1-LzEM4NFU8HRQRT1Vnjzz2jEUeUw="
     },
     "uport-transports": {
-      "version": "0.0.67",
-      "resolved": "https://registry.npmjs.org/uport-transports/-/uport-transports-0.0.67.tgz",
-      "integrity": "sha512-fzF3VDyXYrcZTnQcCYxUsIH+TeNihi3Z7umrbMs0HGHwOd/z2reigk0DQrAoiwaMLDlJJst6oqT+TPMSwr0rZw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/uport-transports/-/uport-transports-0.1.2.tgz",
+      "integrity": "sha512-Ts/Sdsd6B4EyxwObPOg8aGz8WZESylrWvbxwZZLFw9O0RDIOVwisod9lqQUe/WDYyz5kADt48XAP4mrpbdPvKA==",
       "requires": {
         "async": "^2.6.0",
         "base64url": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "uport-credentials": "^1.0.0-alpha-4",
     "uport-did-resolver": "0.0.3",
     "uport-lite": "^1.0.2",
-    "uport-transports": "0.0.67"
+    "uport-transports": "^0.1.2"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
This should get the fix from uport-project/uport-transports#35 into connect, fixing duplicate formatting of mobile URIs.