### PR TITLE
Adding protocol to profile url

### DIFF
--- a/src/Connect.js
+++ b/src/Connect.js
@@ -525,7 +525,7 @@ class Connect {
     profile = profile || {
       name: this.appName,
       description: this.description,
-      url: (typeof window !== 'undefined') ? window.location.host : undefined,
+      url: (typeof window !== 'undefined') ? `${window.location.protocol}//${window.location.host}` : undefined,
       profileImage: this.profileImage,
       bannerImage: this.bannerImage,
     }

--- a/test/Connect.js
+++ b/test/Connect.js
@@ -249,7 +249,7 @@ describe('Connect', () => {
       const jwt = {
         name: 'test app',
         description: 'It tests',
-        url: 'localhost:9876'
+        url: 'http://localhost:9876'
       }
 
       await uport.signAndUploadProfile()


### PR DESCRIPTION
This PR adds protocol to auto-generated profile claim

Before `url === 'demo-test.uport.me'`, after `url === 'https://demo-test.uport.me'`