### PR TITLE
bump to 1.1.0-alpha.13 and update credentials/transports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-connect",
-  "version": "1.1.0-alpha.9",
+  "version": "1.1.0-alpha.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7162,6 +7162,15 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "https-did-resolver": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/https-did-resolver/-/https-did-resolver-0.0.3.tgz",
+      "integrity": "sha512-Cne1BMKMKGR0F6hMJqanybLCQ8J4RZ1rvIpWazzt8BYxKYEsAc/qpGyIV+8hsGvA8x3qof15GrLatrf59fsV4w==",
+      "requires": {
+        "did-resolver": "^0.0.4",
+        "xmlhttprequest": "^1.8.0"
+      }
+    },
     "https-proxy-agent": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
@@ -9648,9 +9657,9 @@
       "dev": true
     },
     "map-age-cleaner": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
-      "integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "requires": {
         "p-defer": "^1.0.0"
       }
@@ -14810,14 +14819,15 @@
       "dev": true
     },
     "uport-credentials": {
-      "version": "1.1.0-alpha-2",
-      "resolved": "https://registry.npmjs.org/uport-credentials/-/uport-credentials-1.1.0-alpha-2.tgz",
-      "integrity": "sha512-iHilnDUUg9vq47YcCKev54TfeangrE0GdNFUOC33Ggbv8Im7aTvwXU8RwpI28aH9f4CzZjDm0r7SmM2pKVAFcA==",
+      "version": "1.1.0-alpha-5",
+      "resolved": "https://registry.npmjs.org/uport-credentials/-/uport-credentials-1.1.0-alpha-5.tgz",
+      "integrity": "sha512-4ouzYPj3p0ZrhKfaLLhQhLwXpOG7Ga8ViqTtjMn6q76PKEmfYMtR1RLS/+8TKv9RdMTKeVQz4ISbgouSIxmX1g==",
       "requires": {
         "did-jwt": "^0.0.7",
         "did-resolver": "^0.0.4",
         "ethjs-util": "^0.1.3",
         "ethr-did-resolver": "^0.1.1",
+        "https-did-resolver": "^0.0.3",
         "jsontokens": "^0.7.8",
         "mnid": "^0.1.1",
         "muport-did-resolver": "^0.1.0",
@@ -14827,7 +14837,7 @@
       "dependencies": {
         "did-jwt": {
           "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-0.0.7.tgz",
+          "resolved": "http://registry.npmjs.org/did-jwt/-/did-jwt-0.0.7.tgz",
           "integrity": "sha512-5PR39zJoBd+eK0SuS2cKd9J2ctdBtg2Jfqu9wZ3nOvPDNIfFpwZyBZe8mtJruEc2kZNrJCIAuN1iFLs2fctG0A==",
           "requires": {
             "babel-runtime": "^6.26.0",
@@ -14878,9 +14888,9 @@
       "integrity": "sha1-LzEM4NFU8HRQRT1Vnjzz2jEUeUw="
     },
     "uport-transports": {
-      "version": "0.2.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/uport-transports/-/uport-transports-0.2.0-alpha.4.tgz",
-      "integrity": "sha512-tjh7yXroX7sMAndTkv9hjHUAXHTtGAgL4/4cbYx4M6UG8CM0HYDdtV3Kb7xDZ+Dww9GCFS5PhjEP48TG++g4Xg==",
+      "version": "0.2.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/uport-transports/-/uport-transports-0.2.0-alpha.7.tgz",
+      "integrity": "sha512-PJDPOFchxgKTKaIWxBtSHuUS1hXagwGez0Nz5EN97F+cMzVs3rMVra8SGAO1EryZOfMEOONDra0NjceWYFjZqA==",
       "requires": {
         "async": "^2.6.0",
         "base64url": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-connect",
-  "version": "1.1.0-alpha.9",
+  "version": "1.1.0-alpha.13",
   "description": "Library for integrating uPort into your app frontend",
   "main": "lib/index.js",
   "scripts": {
@@ -110,10 +110,10 @@
     "pubsub-js": "^1.6.0",
     "qs": "^6.2.1",
     "store": "^2.0.12",
-    "uport-credentials": "^1.1.0-alpha-2",
+    "uport-credentials": "^1.1.0-alpha-5",
     "uport-did-resolver": "0.0.3",
     "uport-lite": "^1.0.2",
-    "uport-transports": "^0.2.0-alpha.4"
+    "uport-transports": "^0.2.0-alpha.7"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
Syncing up latest develop branches on all libs, and deploying latest to demo.uport.space