### PR TITLE
feat: allow verification sig req to specify exp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14732,9 +14732,9 @@
       "dev": true
     },
     "uport-credentials": {
-      "version": "1.0.0-alpha-4",
-      "resolved": "https://registry.npmjs.org/uport-credentials/-/uport-credentials-1.0.0-alpha-4.tgz",
-      "integrity": "sha512-KtWkcZnQVndRx9EmTlroprbqLNjZ1Z8LyOe8gfqDE/0uy0mcmL1jZMLrmZKrb42Le2eBmz1Yb3zy55kFalIbSQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uport-credentials/-/uport-credentials-1.0.2.tgz",
+      "integrity": "sha512-Q810MEDPAuOrtI4214sWWvBIDNBEmtNgmM2Y+I5PTJY5RzJONsfYJhpgxMhdjd3qw2NmgHYc/dcGw9+97smc1g==",
       "requires": {
         "did-jwt": "^0.0.7",
         "did-resolver": "^0.0.4",
@@ -14749,7 +14749,7 @@
       "dependencies": {
         "did-jwt": {
           "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-0.0.7.tgz",
+          "resolved": "http://registry.npmjs.org/did-jwt/-/did-jwt-0.0.7.tgz",
           "integrity": "sha512-5PR39zJoBd+eK0SuS2cKd9J2ctdBtg2Jfqu9wZ3nOvPDNIfFpwZyBZe8mtJruEc2kZNrJCIAuN1iFLs2fctG0A==",
           "requires": {
             "babel-runtime": "^6.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-connect",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-connect",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Library for integrating uPort into your app frontend",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "pubsub-js": "^1.6.0",
     "qs": "^6.2.1",
     "store": "^2.0.12",
-    "uport-credentials": "^1.0.0-alpha-4",
+    "uport-credentials": "^1.0.2",
     "uport-did-resolver": "0.0.3",
     "uport-lite": "^1.0.2",
     "uport-transports": "^0.1.2"

--- a/src/Connect.js
+++ b/src/Connect.js
@@ -290,15 +290,21 @@ class Connect {
    *  })
    *
    *  @param    {Object}     unsignedClaim          unsigned claim object which you want the user to attest
-   *  @param    {String}     sub                    the DID which the unsigned claim is about
+   *  @param    {Object}     opts                   an object containing options for the signature request, including the subject
+   *  @param    {String}     opts.sub               the DID which the unsigned claim is about
+   *  @param    {Number}     [opts.exp]             seconds after epic when the request expires
    *  @param    {String}     [id='signVerReq']      string to identify request, later used to get response
-   *  @param    {Object}     [sendOpts]             reference send function options
+   *  @param    {Object}     [sendOpts]             @see this.send function options
    */
-  requestVerificationSignature (unsignedClaim, sub, id = 'verSigReq', sendOpts) {
-    this.credentials.createVerificationSignatureRequest(unsignedClaim, {sub, aud: this.did, callbackUrl: this.genCallback(id)})
+  requestVerificationSignature (unsignedClaim, opts, id = 'verSigReq', sendOpts) {
+    if (typeof opts === 'string') {
+      console.warn('The subject argument is deprecated, use option object with {sub: sub, ...}')
+      opts = {sub: opts}
+    }
+
+    this.credentials.createVerificationSignatureRequest(unsignedClaim, {...opts, aud: this.did, callbackUrl: this.genCallback(id)})
       .then(jwt => this.send(jwt, id, sendOpts))
   }
-
   /**
    *  Creates a [Selective Disclosure Request JWT](https://github.com/uport-project/specs/blob/develop/messages/sharereq.md) and sends request message to uPort client.
    *

--- a/src/Connect.js
+++ b/src/Connect.js
@@ -292,7 +292,7 @@ class Connect {
    *  @param    {Object}     unsignedClaim          unsigned claim object which you want the user to attest
    *  @param    {Object}     opts                   an object containing options for the signature request, including the subject
    *  @param    {String}     opts.sub               the DID which the unsigned claim is about
-   *  @param    {Number}     [opts.exp]             seconds after epic when the request expires
+   *  @param    {Number}     [opts.expiresIn]       seconds after current time when the requested verifiable claim will expire
    *  @param    {String}     [id='signVerReq']      string to identify request, later used to get response
    *  @param    {Object}     [sendOpts]             @see this.send function options
    */
@@ -300,6 +300,8 @@ class Connect {
     if (typeof opts === 'string') {
       console.warn('The subject argument is deprecated, use option object with {sub: sub, ...}')
       opts = {sub: opts}
+    } else if (!opts.sub) {
+      throw new Error(`Missing required field sub in opts.  Received: ${opts}`)
     }
 
     this.credentials.createVerificationSignatureRequest(unsignedClaim, {...opts, aud: this.did, callbackUrl: this.genCallback(id)})

--- a/src/Connect.js
+++ b/src/Connect.js
@@ -300,7 +300,7 @@ class Connect {
     if (typeof opts === 'string') {
       console.warn('The subject argument is deprecated, use option object with {sub: sub, ...}')
       opts = {sub: opts}
-    } else if (!opts.sub) {
+    } else if (!opts || !opts.sub) {
       throw new Error(`Missing required field sub in opts.  Received: ${opts}`)
     }
 

--- a/test/Connect.js
+++ b/test/Connect.js
@@ -279,8 +279,8 @@ describe('Connect', () => {
       uport.onResponse(id).then((res) => {
         expect(res.payload).to.equal('test')
         done()
-        return
       })
+
       uport.PubSub.publish(id,response)
     })
 
@@ -307,7 +307,7 @@ describe('Connect', () => {
       window.location.hash = `access_token=${JWTReq}&id=${id}`
     })
 
-    it('calls verifies responses with processDislcosurePayload', (done) => {
+    it('verifies responses with processDislcosurePayload', (done) => {
       const uport = new Connect('testApp')
       const verify = sinon.stub().resolves()
       uport.credentials.processDisclosurePayload = verify
@@ -484,37 +484,63 @@ describe('Connect', () => {
         claim: { hello: 'world' },
         sub: 'did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG'
       }
+      const jwt = "a.fake.jwt"
+      const sendOpts = {send: 'opts'}
+      const requestId = 'id'
 
-      uport.send = (url) => {
-        const jwt = message.util.getURLJWT(url)
-        verifyJWT(jwt, {audience: uport.keypair.did}).then(({payload, issuer}) => {
-          expect(issuer).to.equal(uport.keypair.did)
-          expect(payload.claim).to.deep.equal(cred.claim)
-          done()
-        })
+      uport.credentials.createVerification = (content) => {
+        // const jwt = message.util.getURLJWT(url)
+        expect(content).to.equal(cred)
+        console.log('here')
+        return Promise.resolve(jwt)
       }
 
-      uport.sendVerification(cred)
+      uport.send = (msg, id, opts) => {
+        console.log(msg, id, opts)
+        // expect(msg).to.match(/\/topic\/[a-zA-Z0-9-_]{16}/)
+        expect(opts).to.deep.equal(sendOpts)
+        expect(id).to.equal(requestId)
+        done()
+      }
+
+      uport.sendVerification(cred, requestId, sendOpts)
     })
   })
 
   /*********************************************************************/
 
   describe('requestVerificationSignature', () => {
-    it('Creates sign verification request signed by the configured keypair', (done) => {
+    const unsignedClaim = { hello: 'world' }
+    const subject = 'did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG'
+    const sendOpts = {send: 'opts'}
+    const requestId = 'abcdefg'
+    it('Creates a verification signature request signed by the configured keypair and sends', (done) => {
       const uport = new Connect('testApp')
-      const unsignedClaim = { hello: 'world' }
-      const sub = 'did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG'
 
-      uport.send = (jwt) => {
-        verifyJWT(jwt, {audience: uport.keypair.did}).then(({payload, issuer}) => {
-          expect(issuer).to.equal(uport.keypair.did)
-          expect(payload.unsignedClaim).to.deep.equal(unsignedClaim)
-          done()
-        })
+      uport.credentials.createVerificationSignatureRequest = (claim, {sub, aud, callbackUrl}) => {
+        expect(claim).to.deep.equal(unsignedClaim)
+        expect(sub).to.equal(subject)
+        expect(aud).to.equal(uport.did)
+        return Promise.resolve('jwt')
       }
 
-      uport.requestVerificationSignature(unsignedClaim, sub)
+      uport.send = (jwt, id, opts) => {
+        expect(id).to.equal(requestId)
+        expect(opts).to.deep.equal(sendOpts)
+        done()
+      }
+
+      uport.requestVerificationSignature(unsignedClaim, subject, requestId, sendOpts)
+    })
+
+    it('passes through an expiration field', (done) => {
+      const uport = new Connect('testapp')
+      const exp = 12345678
+      uport.credentials.createVerificationSignatureRequest = (claim, opts) => {
+        expect(opts.exp).to.equal(exp)
+        done()
+      }
+      uport.requestVerificationSignature(unsignedClaim, {sub: subject, exp})
     })
   })
 
@@ -616,7 +642,7 @@ describe('transports', () => {
     })
   })
 
-  it('uses universal links on first mobile request, and deep links thereafter', (done) => {
+  it('uses deep links', (done) => {
     // Set up uriHandler to check uri scheme
     let shouldBeDeeplink = true
     const mobileUriHandler = (uri) => {

--- a/test/Connect.js
+++ b/test/Connect.js
@@ -491,12 +491,10 @@ describe('Connect', () => {
       uport.credentials.createVerification = (content) => {
         // const jwt = message.util.getURLJWT(url)
         expect(content).to.equal(cred)
-        console.log('here')
         return Promise.resolve(jwt)
       }
 
       uport.send = (msg, id, opts) => {
-        console.log(msg, id, opts)
         // expect(msg).to.match(/\/topic\/[a-zA-Z0-9-_]{16}/)
         expect(opts).to.deep.equal(sendOpts)
         expect(id).to.equal(requestId)
@@ -531,6 +529,11 @@ describe('Connect', () => {
       }
 
       uport.requestVerificationSignature(unsignedClaim, subject, requestId, sendOpts)
+    })
+
+    it('throws an error if sub is missing', () => {
+      const uport = new Connect('testapp')
+      expect(() => uport.requestVerificationSignature({test: 'hello'}, {missing: 'sub'})).to.throw()
     })
 
     it('passes through an expiration field', (done) => {


### PR DESCRIPTION
This just adds `exp` as an option in the second parameter to `requestVerificationSignature()`.  This depends on a similar fix in uport-project/uport-credentials#138

Closes #236 