### PR TITLE
Allow an empty "sub" field

### DIFF
--- a/src/Connect.js
+++ b/src/Connect.js
@@ -334,8 +334,6 @@ class Connect {
     if (typeof opts === 'string') {
       console.warn('The subject argument is deprecated, use option object with {sub: sub, ...}')
       opts = {sub: opts}
-    } else if (!opts || !opts.sub) {
-      throw new Error(`Missing required field sub in opts.  Received: ${opts}`)
     }
 
     this.credentials.createVerificationSignatureRequest(unsignedClaim, {...opts, aud: this.did, callbackUrl: this.genCallback(id), vc: this.vc})

--- a/test/unit/Connect.js
+++ b/test/unit/Connect.js
@@ -661,17 +661,6 @@ describe('Connect', () => {
       uport.requestVerificationSignature(unsignedClaim, subject, requestId, sendOpts)
     })
 
-    it('throws an error if sub is missing', async () => {
-      const uport = new Connect('testapp', { vc })
-      try {
-        await uport.requestVerificationSignature({ test: 'hello' }, { missing: 'sub' })
-        expect(true).to.be.false
-      } catch (e) {
-        // GOOD
-        expect(e).not.to.be.null
-      }
-    })
-
     it('passes through an expiration field', (done) => {
       const uport = new Connect('testapp', { vc })
       const exp = 12345678


### PR DESCRIPTION
In the JWT spec, the "sub" field is optional.  https://tools.ietf.org/html/rfc7519#section-4.1.2

I have cases where a claim involves multiple subjects, so this requirement has caused some hacking to supply a dummy value.  (I can also imagine claims about no subject in particular.)  I propose it be made optional in this library to allow for flexibility by the users.
